### PR TITLE
[Chore-6] Sore session in Postgres instead of memory

### DIFF
--- a/conf/app.conf
+++ b/conf/app.conf
@@ -4,3 +4,11 @@ httpport = ${PORT||8080}
 runmode = ${APP_RUN_MODE||dev}
 db_url = ${DATABASE_URL}
 SessionOn = true
+
+[dev]
+SessionProvider = postgresql
+SessionProviderConfig = ${DATABASE_URL}
+
+[prod]
+SessionProvider = postgresql
+SessionProviderConfig = ${DATABASE_URL}

--- a/database/migrations/20210218_130252_create_session.go
+++ b/database/migrations/20210218_130252_create_session.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"github.com/beego/beego/v2/client/orm/migration"
+	"log"
+)
+
+// DO NOT MODIFY
+type CreateSession_20210218_130252 struct {
+	migration.Migration
+}
+
+// DO NOT MODIFY
+func init() {
+	m := &CreateSession_20210218_130252{}
+	m.Created = "20210218_130252"
+
+	err := migration.Register("CreateSession_20210218_130252", m)
+	if err != nil {
+		log.Fatal("Migration failed:", err)
+	}
+}
+
+// Run the migrations
+func (m *CreateSession_20210218_130252) Up() {
+	m.SQL(`CREATE TABLE "session"
+		(
+			session_key	char(64) NOT NULL,
+			session_data	bytea,
+			session_expiry	timestamp NOT NULL,
+			CONSTRAINT session_key PRIMARY KEY(session_key)
+		);`)
+}
+
+// Reverse the migrations
+func (m *CreateSession_20210218_130252) Down() {
+	m.SQL(`DROP TABLE "session";`)
+}

--- a/initializers/database.go
+++ b/initializers/database.go
@@ -15,6 +15,8 @@ func SetUpDatabase() {
 		log.Fatal("Run mode not found: ", err)
 	}
 
+	orm.Debug = runMode == "dev"
+
 	dbURL, err := web.AppConfig.String("db_url")
 	if err != nil {
 		log.Fatal("Database URL not found: ", err)
@@ -30,6 +32,7 @@ func SetUpDatabase() {
 		log.Fatal("Database Registration failed: ", err)
 	}
 
+	// TODO: remove this on the chore task to ensure same db structure on every ENV
 	verbose := runMode == "dev"
 	err = orm.RunSyncdb("default", false, verbose)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	oauth_services "go-google-scraper-challenge/services/oauth"
 
 	"github.com/beego/beego/v2/server/web"
+	_ "github.com/beego/beego/v2/server/web/session/postgres"
 	"github.com/joho/godotenv"
 	_ "github.com/lib/pq"
 )


### PR DESCRIPTION
## What happened 👀

Resolved #33 

By default Beego stores the session in memory so when we restart the server the session has gone, to keep the session when the server is not running we need to store the session somewhere else. So on this PR, we store the session on Postgres instead

- create a `session` table
- set Postgres as session provider on development and production environment
- on the test environment we still store session on memory so we don't have to clear the session table on every test cases

## Insight 📝

N/A

## Proof Of Work 📹

_The session still there after restarting the server_
![go_postgres_session](https://user-images.githubusercontent.com/1772999/108325807-14d2f900-71fc-11eb-8b43-9695c431386b.gif)

