### PR TITLE
[Chore-7] Make sure database in test environment is the same as in the development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,3 @@ go-google-scraper-challenge
 
 # Generated files
 /static/*
-database/schema.sql

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ go-google-scraper-challenge
 
 # Generated files
 /static/*
+database/schema.sql

--- a/Makefile
+++ b/Makefile
@@ -45,9 +45,13 @@ db/setup:
 
 db/migrate:
 	bee migrate -driver=postgres -conn="$(DATABASE_URL)"
+	pg_dump $(DATABASE_URL) --schema-only -f ./database/schema.sql
 
 db/rollback:
 	bee migrate rollback -driver=postgres -conn="$(DATABASE_URL)"
+
+db/tear-down:
+	docker-compose -f docker-compose.dev.yml down
 
 lint:
 	golangci-lint run
@@ -57,5 +61,6 @@ test:
 
 test/run:
 	docker-compose -f docker-compose.test.yml up -d
+	psql $(DATABASE_URL) -f ./database/schema.sql
 	APP_RUN_MODE=test go test -v -p 1 ./...
 	docker-compose -f docker-compose.test.yml down

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,5 @@ test:
 
 test/run:
 	docker-compose -f docker-compose.test.yml up -d
-	psql $(DATABASE_URL) -f ./database/schema.sql
 	APP_RUN_MODE=test go test -v -p 1 ./...
 	docker-compose -f docker-compose.test.yml down

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,0 +1,186 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 12.3 (Debian 12.3-1.pgdg100+1)
+-- Dumped by pg_dump version 13.1
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: citext; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS citext WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION citext; Type: COMMENT; Schema: -; Owner: 
+--
+
+COMMENT ON EXTENSION citext IS 'data type for case-insensitive character strings';
+
+
+--
+-- Name: migrations_status; Type: TYPE; Schema: public; Owner: postgres
+--
+
+CREATE TYPE public.migrations_status AS ENUM (
+    'update',
+    'rollback'
+);
+
+
+ALTER TYPE public.migrations_status OWNER TO postgres;
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: migrations; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.migrations (
+    id_migration integer NOT NULL,
+    name character varying(255) DEFAULT NULL::character varying,
+    created_at timestamp without time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    statements text,
+    rollback_statements text,
+    status public.migrations_status
+);
+
+
+ALTER TABLE public.migrations OWNER TO postgres;
+
+--
+-- Name: migrations_id_migration_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.migrations_id_migration_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.migrations_id_migration_seq OWNER TO postgres;
+
+--
+-- Name: migrations_id_migration_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.migrations_id_migration_seq OWNED BY public.migrations.id_migration;
+
+
+--
+-- Name: session; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.session (
+    session_key character(64) NOT NULL,
+    session_data bytea,
+    session_expiry timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.session OWNER TO postgres;
+
+--
+-- Name: users; Type: TABLE; Schema: public; Owner: postgres
+--
+
+CREATE TABLE public.users (
+    id integer NOT NULL,
+    email public.citext,
+    hashed_password text,
+    created_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+ALTER TABLE public.users OWNER TO postgres;
+
+--
+-- Name: user_id_seq; Type: SEQUENCE; Schema: public; Owner: postgres
+--
+
+CREATE SEQUENCE public.user_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+ALTER TABLE public.user_id_seq OWNER TO postgres;
+
+--
+-- Name: user_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: postgres
+--
+
+ALTER SEQUENCE public.user_id_seq OWNED BY public.users.id;
+
+
+--
+-- Name: migrations id_migration; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.migrations ALTER COLUMN id_migration SET DEFAULT nextval('public.migrations_id_migration_seq'::regclass);
+
+
+--
+-- Name: users id; Type: DEFAULT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.users ALTER COLUMN id SET DEFAULT nextval('public.user_id_seq'::regclass);
+
+
+--
+-- Name: migrations migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.migrations
+    ADD CONSTRAINT migrations_pkey PRIMARY KEY (id_migration);
+
+
+--
+-- Name: session session_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.session
+    ADD CONSTRAINT session_key PRIMARY KEY (session_key);
+
+
+--
+-- Name: users user_email_key; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.users
+    ADD CONSTRAINT user_email_key UNIQUE (email);
+
+
+--
+-- Name: users user_pkey; Type: CONSTRAINT; Schema: public; Owner: postgres
+--
+
+ALTER TABLE ONLY public.users
+    ADD CONSTRAINT user_pkey PRIMARY KEY (id);
+
+
+--
+-- PostgreSQL database dump complete
+--
+

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -9,3 +9,9 @@ services:
       - POSTGRES_HOST_AUTH_METHOD=trust
     ports:
       - "5432:5432"
+    volumes:
+      - ./database/schema.sql:/docker-entrypoint-initdb.d/1-schema.sql
+      - pg_data:/var/lib/postgresql/data
+
+volumes:
+  pg_data:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - ./database/schema.sql:/docker-entrypoint-initdb.d/1-schema.sql
+      - ./database/schema.sql:/docker-entrypoint-initdb.d/init.sql
       - pg_data:/var/lib/postgresql/data
 
 volumes:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -10,8 +10,4 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - ./database/schema.sql:/docker-entrypoint-initdb.d/1-schema.sql
-      - pg_data:/var/lib/postgresql/data
-
-volumes:
-  pg_data:
+      - ./database/schema.sql:/docker-entrypoint-initdb.d/init.sql

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - ./database/schema.sql:/docker-entrypoint-initdb.d/init.sql
+      - ./database/schema.sql:/docker-entrypoint-initdb.d/1-schema.sql
       - pg_data:/var/lib/postgresql/data
 
 volumes:

--- a/initializers/database.go
+++ b/initializers/database.go
@@ -31,11 +31,4 @@ func SetUpDatabase() {
 	if err != nil {
 		log.Fatal("Database Registration failed: ", err)
 	}
-
-	// TODO: remove this on the chore task to ensure same db structure on every ENV
-	verbose := runMode == "dev"
-	err = orm.RunSyncdb("default", false, verbose)
-	if err != nil {
-		log.Fatal("Database Sync failed: ", err)
-	}
 }


### PR DESCRIPTION
## What happened 👀

Resolved #36 

Currently, no migration was run before the test, and while running `orm.RunSyncdb` Beego ORM will sync the database tables according to the `struct` on models, which might produce a table structure that differs from the migration.
So I decided to generate the schema and load that schema before running the test.

- [x] generate the schema whenever migration run
- [x] don't use `orm.RunSyncdb` 

I decided to use the schema because running migration needs Bee command which needs to be installed every time before running the test, which will slow the development process, also the workaround to run migration without Bee command is painful.

## Insight 📝

N/A

## Proof Of Work 📹

All test cases should pass

The test database should contain `migrations` table

Before | After
------- | -------
![Screen Shot 2564-02-25 at 16 13 27](https://user-images.githubusercontent.com/1772999/109130739-a60a1880-7784-11eb-9ab2-3b88ac9d46a6.png) | ![Screen Shot 2564-02-25 at 16 26 10](https://user-images.githubusercontent.com/1772999/109132282-3c8b0980-7786-11eb-8208-0441e5a980a9.png)

