### PR TITLE
[Bug] Missing database relation on Staging and Production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,5 +40,7 @@ jobs:
           heroku_app_name: $HEROKU_APP_NAME
           heroku_email: ${{ secrets.HEROKU_ACCOUNT_EMAIL }}
           usedocker: true
+          docker_build_args: |
+            DATABASE_URL
         env:
           APP_RUN_MODE: 'prod'


### PR DESCRIPTION
Resolved #45 

## What happened 👀

Regarding [this hotfix](https://github.com/carryall/go-google-scraper-challenge/pull/46) the deployment failed because of missing args for docker 🤦🏼 

## Insight 📝

N/A

## Proof Of Work 📹

After merging this PR the staging site should works
