### PR TITLE
[Chore-58] Move all error and success messages to a separate file

### DIFF
--- a/constants/file.go
+++ b/constants/file.go
@@ -1,0 +1,9 @@
+package constants
+
+const (
+	FileEmpty         = "File cannot be empty"
+	FileTypeInvalid   = "Incorrect file type"
+	FileUnreadable    = "Unreadable file"
+	FileUploadFail    = "Failed to upload file, please make sure the file is not corrupted"
+	FileUploadSuccess = "Successfully uploaded the file, the result status would be updated soon"
+)

--- a/constants/oauth.go
+++ b/constants/oauth.go
@@ -1,0 +1,6 @@
+package constants
+
+const (
+	OAuthClientCreateSuccess = "The Client was successfully created"
+	OAuthClientNotFound      = "OAuth client not found"
+)

--- a/constants/registration.go
+++ b/constants/registration.go
@@ -1,0 +1,6 @@
+package constants
+
+const (
+	UserAlreadyExist        = "User with this email already exist"
+	PasswordConfirmNotMatch = "Password confirmation must match the password"
+)

--- a/constants/session.go
+++ b/constants/session.go
@@ -1,0 +1,8 @@
+package constants
+
+const (
+	SignInFail     = "Incorrect email or password"
+	SignInSuccess  = "Successfully signed in"
+	SignOutFail    = "Failed to sign out"
+	SignOutSuccess = "Successfully signed out"
+)

--- a/constants/user.go
+++ b/constants/user.go
@@ -1,0 +1,5 @@
+package constants
+
+const (
+	UserCreateSuccess = "The user was successfully created"
+)

--- a/controllers/oauth_client.go
+++ b/controllers/oauth_client.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"net/http"
 
+	"go-google-scraper-challenge/constants"
 	"go-google-scraper-challenge/services/oauth"
 
 	"github.com/beego/beego/v2/server/web"
@@ -47,7 +48,7 @@ func (c *OAuthClientController) Create() {
 		flash.Store(&c.Controller)
 		c.Redirect("/oauth_client", http.StatusFound)
 	} else {
-		flash.Success("The Client was successfully created")
+		flash.Success(constants.OAuthClientCreateSuccess)
 		flash.Store(&c.Controller)
 		c.Redirect("/oauth_client/"+oauthClient.ClientID, http.StatusFound)
 	}
@@ -69,7 +70,7 @@ func (c *OAuthClientController) Show() {
 	oauthClient, err := oauth.GetClientStore().GetByID(clientID)
 	if err != nil {
 		flash := web.NewFlash()
-		flash.Error("OAuth client not found")
+		flash.Error(constants.OAuthClientNotFound)
 		flash.Store(&c.Controller)
 		c.Redirect("/oauth_client", http.StatusFound)
 	} else {

--- a/controllers/oauth_client_test.go
+++ b/controllers/oauth_client_test.go
@@ -3,6 +3,7 @@ package controllers_test
 import (
 	"net/http"
 
+	"go-google-scraper-challenge/constants"
 	"go-google-scraper-challenge/initializers"
 	. "go-google-scraper-challenge/tests/helpers"
 
@@ -34,7 +35,7 @@ var _ = Describe("OAuthClientController", func() {
 			response := MakeRequest("POST", "/oauth_client", body)
 			flash := GetFlashMessage(response.Cookies())
 
-			Expect(flash.Data["success"]).To(Equal("The Client was successfully created"))
+			Expect(flash.Data["success"]).To(Equal(constants.OAuthClientCreateSuccess))
 			Expect(flash.Data["error"]).To(BeEmpty())
 		})
 	})
@@ -69,7 +70,7 @@ var _ = Describe("OAuthClientController", func() {
 				response := MakeRequest("GET", "/oauth_client/invalid_id", nil)
 				flash := GetFlashMessage(response.Cookies())
 
-				Expect(flash.Data["error"]).To(Equal("OAuth client not found"))
+				Expect(flash.Data["error"]).To(Equal(constants.OAuthClientNotFound))
 				Expect(flash.Data["success"]).To(BeEmpty())
 			})
 		})

--- a/controllers/result.go
+++ b/controllers/result.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"net/http"
 
+	"go-google-scraper-challenge/constants"
 	"go-google-scraper-challenge/forms"
 	"go-google-scraper-challenge/helpers"
 	"go-google-scraper-challenge/models"
@@ -56,7 +57,7 @@ func (c *ResultController) Create() {
 
 	file, fileHeader, err := c.GetFile("file")
 	if err != nil {
-		flash.Error("Failed to upload file, please make sure the file is not corrupted")
+		flash.Error(constants.FileUploadFail)
 	} else {
 		uploadForm := forms.UploadForm{
 			File: file,
@@ -67,7 +68,7 @@ func (c *ResultController) Create() {
 		if err != nil {
 			flash.Error(err.Error())
 		} else {
-			flash.Success("Successfully uploaded the file, the result status would be updated soon")
+			flash.Success(constants.FileUploadSuccess)
 			scraper.Search(keywords, c.CurrentUser)
 		}
 	}

--- a/controllers/result_test.go
+++ b/controllers/result_test.go
@@ -3,6 +3,7 @@ package controllers_test
 import (
 	"net/http"
 
+	"go-google-scraper-challenge/constants"
 	"go-google-scraper-challenge/initializers"
 	"go-google-scraper-challenge/models"
 	. "go-google-scraper-challenge/tests/helpers"
@@ -162,7 +163,7 @@ var _ = Describe("ResultController", func() {
 				flash := GetFlashMessage(response.Cookies())
 
 				Expect(flash.Data["success"]).To(BeEmpty())
-				Expect(flash.Data["error"]).To(Equal("Incorrect file type"))
+				Expect(flash.Data["error"]).To(Equal(constants.FileTypeInvalid))
 			})
 		})
 

--- a/controllers/session.go
+++ b/controllers/session.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"net/http"
 
+	"go-google-scraper-challenge/constants"
 	"go-google-scraper-challenge/forms"
 
 	"github.com/beego/beego/v2/server/web"
@@ -64,7 +65,7 @@ func (c *SessionController) Create() {
 	} else {
 		c.SetCurrentUser(user)
 
-		flash.Success("Successfully signed in")
+		flash.Success(constants.SignInSuccess)
 		redirectPath = "/"
 	}
 
@@ -86,10 +87,10 @@ func (c *SessionController) Delete() {
 
 	err := c.ClearCurrentUser()
 	if err != nil {
-		flash.Error("Failed to sign out")
+		flash.Error(constants.SignOutFail)
 		redirectPath = "/"
 	} else {
-		flash.Success("Successfully signed out")
+		flash.Success(constants.SignOutSuccess)
 		redirectPath = "/signin"
 	}
 

--- a/controllers/session.go
+++ b/controllers/session.go
@@ -56,11 +56,9 @@ func (c *SessionController) Create() {
 		flash.Error(err.Error())
 	}
 
-	user, errs := form.Save()
-	if len(errs) > 0 {
-		for _, err := range errs {
-			flash.Error(err.Error())
-		}
+	user, err := form.Save()
+	if err != nil {
+		flash.Error(err.Error())
 		redirectPath = "/signin"
 	} else {
 		c.SetCurrentUser(user)

--- a/controllers/session_test.go
+++ b/controllers/session_test.go
@@ -3,6 +3,7 @@ package controllers_test
 import (
 	"net/http"
 
+	"go-google-scraper-challenge/constants"
 	"go-google-scraper-challenge/controllers"
 	"go-google-scraper-challenge/initializers"
 	. "go-google-scraper-challenge/tests/helpers"
@@ -186,7 +187,7 @@ var _ = Describe("SessionController", func() {
 						response := MakeRequest("POST", "/sessions", body)
 						flash := GetFlashMessage(response.Cookies())
 
-						Expect(flash.Data["error"]).To(Equal("Incorrect email or password"))
+						Expect(flash.Data["error"]).To(Equal(constants.SignInFail))
 						Expect(flash.Data["success"]).To(BeEmpty())
 					})
 
@@ -226,7 +227,7 @@ var _ = Describe("SessionController", func() {
 						response := MakeRequest("POST", "/sessions", body)
 						flash := GetFlashMessage(response.Cookies())
 
-						Expect(flash.Data["error"]).To(Equal("Incorrect email or password"))
+						Expect(flash.Data["error"]).To(Equal(constants.SignInFail))
 						Expect(flash.Data["success"]).To(BeEmpty())
 					})
 

--- a/controllers/user.go
+++ b/controllers/user.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"go-google-scraper-challenge/constants"
 	"go-google-scraper-challenge/forms"
 	"net/http"
 
@@ -60,7 +61,7 @@ func (c *UserController) Create() {
 		}
 		redirectPath = "/signup"
 	} else {
-		flash.Success("The user was successfully created")
+		flash.Success(constants.UserCreateSuccess)
 		redirectPath = "/signin"
 	}
 

--- a/controllers/user.go
+++ b/controllers/user.go
@@ -54,11 +54,9 @@ func (c *UserController) Create() {
 		flash.Error(err.Error())
 	}
 
-	_, errors := form.Save()
-	if len(errors) > 0 {
-		for _, err := range errors {
-			flash.Error(err.Error())
-		}
+	_, err = form.Save()
+	if err != nil {
+		flash.Error(err.Error())
 		redirectPath = "/signup"
 	} else {
 		flash.Success(constants.UserCreateSuccess)

--- a/controllers/user_test.go
+++ b/controllers/user_test.go
@@ -3,6 +3,7 @@ package controllers_test
 import (
 	"net/http"
 
+	"go-google-scraper-challenge/constants"
 	"go-google-scraper-challenge/initializers"
 	. "go-google-scraper-challenge/tests/helpers"
 
@@ -62,7 +63,7 @@ var _ = Describe("UserController", func() {
 					response := MakeRequest("POST", "/users", body)
 					flash := GetFlashMessage(response.Cookies())
 
-					Expect(flash.Data["success"]).To(Equal("The user was successfully created"))
+					Expect(flash.Data["success"]).To(Equal(constants.UserCreateSuccess))
 					Expect(flash.Data["error"]).To(BeEmpty())
 				})
 			})

--- a/forms/registration.go
+++ b/forms/registration.go
@@ -1,6 +1,7 @@
 package forms
 
 import (
+	"go-google-scraper-challenge/constants"
 	"go-google-scraper-challenge/helpers"
 	"go-google-scraper-challenge/models"
 
@@ -18,14 +19,14 @@ type RegistrationForm struct {
 func (rf *RegistrationForm) Valid(v *validation.Validation) {
 	userExist := models.UserEmailAlreadyExist(rf.Email)
 	if userExist {
-		validationError := v.SetError("Email", "User with this email already exist")
+		validationError := v.SetError("Email", constants.UserAlreadyExist)
 		if validationError == nil {
 			logs.Info("Failed to set error on validation")
 		}
 	}
 
 	if rf.Password != rf.PasswordConfirmation {
-		validationError := v.SetError("PasswordConfirmation", "Password confirmation must match the password")
+		validationError := v.SetError("PasswordConfirmation", constants.PasswordConfirmNotMatch)
 		if validationError == nil {
 			logs.Info("Failed to set error on validation")
 		}

--- a/forms/registration.go
+++ b/forms/registration.go
@@ -5,7 +5,6 @@ import (
 	"go-google-scraper-challenge/helpers"
 	"go-google-scraper-challenge/models"
 
-	"github.com/beego/beego/v2/core/logs"
 	"github.com/beego/beego/v2/core/validation"
 )
 
@@ -19,17 +18,11 @@ type RegistrationForm struct {
 func (rf *RegistrationForm) Valid(v *validation.Validation) {
 	userExist := models.UserEmailAlreadyExist(rf.Email)
 	if userExist {
-		validationError := v.SetError("Email", constants.UserAlreadyExist)
-		if validationError == nil {
-			logs.Info("Failed to set error on validation")
-		}
+		_ = v.SetError("Email", constants.UserAlreadyExist)
 	}
 
 	if rf.Password != rf.PasswordConfirmation {
-		validationError := v.SetError("PasswordConfirmation", constants.PasswordConfirmNotMatch)
-		if validationError == nil {
-			logs.Info("Failed to set error on validation")
-		}
+		_ = v.SetError("PasswordConfirmation", constants.PasswordConfirmNotMatch)
 	}
 }
 

--- a/forms/registration.go
+++ b/forms/registration.go
@@ -19,6 +19,8 @@ func (rf *RegistrationForm) Valid(v *validation.Validation) {
 	userExist := models.UserEmailAlreadyExist(rf.Email)
 	if userExist {
 		_ = v.SetError("Email", constants.UserAlreadyExist)
+
+		return
 	}
 
 	if rf.Password != rf.PasswordConfirmation {
@@ -28,26 +30,21 @@ func (rf *RegistrationForm) Valid(v *validation.Validation) {
 
 // Save validates registration form and adds a new User with email and password from the form,
 // returns errors if validation failed or cannot add the user to database.
-func (rf *RegistrationForm) Save() (*models.User, []error) {
+func (rf *RegistrationForm) Save() (*models.User, error) {
 	validation := validation.Validation{}
 
 	valid, err := validation.Valid(rf)
 	if err != nil {
-		return nil, []error{err}
+		return nil, err
 	}
 
 	if !valid {
-		var errors []error
-		for _, err := range validation.Errors {
-			errors = append(errors, err)
-		}
-
-		return nil, errors
+		return nil, validation.Errors[0]
 	}
 
 	hashedPassword, err := helpers.HashPassword(rf.Password)
 	if err != nil {
-		return nil, []error{err}
+		return nil, err
 	}
 
 	user := &models.User{
@@ -57,13 +54,13 @@ func (rf *RegistrationForm) Save() (*models.User, []error) {
 
 	userID, err := models.CreateUser(user)
 	if err != nil {
-		return nil, []error{err}
+		return nil, err
 	}
 
 	user, err = models.GetUserById(userID)
 	if err != nil {
-		return nil, []error{err}
+		return nil, err
 	}
 
-	return user, []error{}
+	return user, nil
 }

--- a/forms/registration_test.go
+++ b/forms/registration_test.go
@@ -1,6 +1,7 @@
 package forms_test
 
 import (
+	"go-google-scraper-challenge/constants"
 	"go-google-scraper-challenge/forms"
 	"go-google-scraper-challenge/initializers"
 	. "go-google-scraper-challenge/tests/helpers"
@@ -46,7 +47,7 @@ var _ = Describe("Forms/RegistrationForm", func() {
 
 					Expect(len(formValidation.Errors)).To(Equal(1))
 					Expect(formValidation.Errors[0].Key).To(Equal("Email"))
-					Expect(formValidation.Errors[0].Message).To(Equal("User with this email already exist"))
+					Expect(formValidation.Errors[0].Message).To(Equal(constants.UserAlreadyExist))
 				})
 			})
 
@@ -63,7 +64,7 @@ var _ = Describe("Forms/RegistrationForm", func() {
 
 					Expect(len(formValidation.Errors)).To(Equal(1))
 					Expect(formValidation.Errors[0].Key).To(Equal("PasswordConfirmation"))
-					Expect(formValidation.Errors[0].Message).To(Equal("Password confirmation must match the password"))
+					Expect(formValidation.Errors[0].Message).To(Equal(constants.PasswordConfirmNotMatch))
 				})
 			})
 		})
@@ -116,7 +117,7 @@ var _ = Describe("Forms/RegistrationForm", func() {
 					userID, errors := form.Save()
 
 					Expect(userID).To(BeNil())
-					Expect(errors[0].Error()).To(Equal("User with this email already exist"))
+					Expect(errors[0].Error()).To(Equal(constants.UserAlreadyExist))
 				})
 			})
 
@@ -223,7 +224,7 @@ var _ = Describe("Forms/RegistrationForm", func() {
 					userID, errors := form.Save()
 
 					Expect(userID).To(BeNil())
-					Expect(errors[0].Error()).To(Equal("Password confirmation must match the password"))
+					Expect(errors[0].Error()).To(Equal(constants.PasswordConfirmNotMatch))
 				})
 			})
 		})

--- a/forms/registration_test.go
+++ b/forms/registration_test.go
@@ -80,8 +80,8 @@ var _ = Describe("Forms/RegistrationForm", func() {
 					PasswordConfirmation: password,
 				}
 
-				userID, errors := form.Save()
-				if len(errors) > 0 {
+				userID, err := form.Save()
+				if err != nil {
 					Fail("Failed to save form")
 				}
 
@@ -96,9 +96,9 @@ var _ = Describe("Forms/RegistrationForm", func() {
 					PasswordConfirmation: password,
 				}
 
-				_, errors := form.Save()
+				_, err := form.Save()
 
-				Expect(len(errors)).To(BeZero())
+				Expect(err).To(BeNil())
 			})
 		})
 
@@ -114,10 +114,10 @@ var _ = Describe("Forms/RegistrationForm", func() {
 						PasswordConfirmation: password,
 					}
 
-					userID, errors := form.Save()
+					userID, err := form.Save()
 
 					Expect(userID).To(BeNil())
-					Expect(errors[0].Error()).To(Equal(constants.UserAlreadyExist))
+					Expect(err.Error()).To(Equal(constants.UserAlreadyExist))
 				})
 			})
 
@@ -130,10 +130,10 @@ var _ = Describe("Forms/RegistrationForm", func() {
 						PasswordConfirmation: password,
 					}
 
-					userID, errors := form.Save()
+					userID, err := form.Save()
 
 					Expect(userID).To(BeNil())
-					Expect(errors[0].Error()).To(Equal("Email must be a valid email address"))
+					Expect(err.Error()).To(Equal("Email must be a valid email address"))
 				})
 			})
 
@@ -146,10 +146,10 @@ var _ = Describe("Forms/RegistrationForm", func() {
 						PasswordConfirmation: password,
 					}
 
-					userID, errors := form.Save()
+					userID, err := form.Save()
 
 					Expect(userID).To(BeNil())
-					Expect(errors[0].Error()).To(Equal("Email must be a valid email address"))
+					Expect(err.Error()).To(Equal("Email must be a valid email address"))
 				})
 			})
 
@@ -161,10 +161,10 @@ var _ = Describe("Forms/RegistrationForm", func() {
 						PasswordConfirmation: faker.Password(),
 					}
 
-					userID, errors := form.Save()
+					userID, err := form.Save()
 
 					Expect(userID).To(BeNil())
-					Expect(errors[0].Error()).To(Equal("Password can not be empty"))
+					Expect(err.Error()).To(Equal("Password can not be empty"))
 				})
 			})
 
@@ -176,10 +176,10 @@ var _ = Describe("Forms/RegistrationForm", func() {
 						PasswordConfirmation: faker.Password(),
 					}
 
-					userID, errors := form.Save()
+					userID, err := form.Save()
 
 					Expect(userID).To(BeNil())
-					Expect(errors[0].Error()).To(Equal("Password minimum size is 6"))
+					Expect(err.Error()).To(Equal("Password minimum size is 6"))
 				})
 			})
 
@@ -191,10 +191,10 @@ var _ = Describe("Forms/RegistrationForm", func() {
 						PasswordConfirmation: "",
 					}
 
-					userID, errors := form.Save()
+					userID, err := form.Save()
 
 					Expect(userID).To(BeNil())
-					Expect(errors[0].Error()).To(Equal("PasswordConfirmation can not be empty"))
+					Expect(err.Error()).To(Equal("PasswordConfirmation can not be empty"))
 				})
 			})
 
@@ -206,10 +206,10 @@ var _ = Describe("Forms/RegistrationForm", func() {
 						PasswordConfirmation: "1234",
 					}
 
-					userID, errors := form.Save()
+					userID, err := form.Save()
 
 					Expect(userID).To(BeNil())
-					Expect(errors[0].Error()).To(Equal("PasswordConfirmation minimum size is 6"))
+					Expect(err.Error()).To(Equal("PasswordConfirmation minimum size is 6"))
 				})
 			})
 
@@ -221,10 +221,10 @@ var _ = Describe("Forms/RegistrationForm", func() {
 						PasswordConfirmation: "does not match the password",
 					}
 
-					userID, errors := form.Save()
+					userID, err := form.Save()
 
 					Expect(userID).To(BeNil())
-					Expect(errors[0].Error()).To(Equal(constants.PasswordConfirmNotMatch))
+					Expect(err.Error()).To(Equal(constants.PasswordConfirmNotMatch))
 				})
 			})
 		})

--- a/forms/session.go
+++ b/forms/session.go
@@ -1,6 +1,7 @@
 package forms
 
 import (
+	"go-google-scraper-challenge/constants"
 	"go-google-scraper-challenge/helpers"
 	"go-google-scraper-challenge/models"
 
@@ -19,14 +20,14 @@ var currentUser *models.User
 func (sf *SessionForm) Valid(v *validation.Validation) {
 	user, err := models.GetUserByEmail(sf.Email)
 	if err != nil {
-		err := v.SetError("Email", "Incorrect email or password")
+		err := v.SetError("Email", constants.SignInFail)
 		if err == nil {
 			logs.Info("Failed to set error on validation")
 		}
 	} else {
 		validPassword := helpers.CompareHashWithPassword(user.HashedPassword, sf.Password)
 		if !validPassword {
-			err := v.SetError("Password", "Incorrect email or password")
+			err := v.SetError("Password", constants.SignInFail)
 			if err == nil {
 				logs.Info("Failed to set error on validation")
 			}

--- a/forms/session.go
+++ b/forms/session.go
@@ -5,7 +5,6 @@ import (
 	"go-google-scraper-challenge/helpers"
 	"go-google-scraper-challenge/models"
 
-	"github.com/beego/beego/v2/core/logs"
 	"github.com/beego/beego/v2/core/validation"
 )
 
@@ -20,17 +19,11 @@ var currentUser *models.User
 func (sf *SessionForm) Valid(v *validation.Validation) {
 	user, err := models.GetUserByEmail(sf.Email)
 	if err != nil {
-		err := v.SetError("Email", constants.SignInFail)
-		if err == nil {
-			logs.Info("Failed to set error on validation")
-		}
+		_ = v.SetError("Email", constants.SignInFail)
 	} else {
 		validPassword := helpers.CompareHashWithPassword(user.HashedPassword, sf.Password)
 		if !validPassword {
-			err := v.SetError("Password", constants.SignInFail)
-			if err == nil {
-				logs.Info("Failed to set error on validation")
-			}
+			_ = v.SetError("Password", constants.SignInFail)
 		} else {
 			currentUser = user
 		}

--- a/forms/session_test.go
+++ b/forms/session_test.go
@@ -1,6 +1,7 @@
 package forms_test
 
 import (
+	"go-google-scraper-challenge/constants"
 	"go-google-scraper-challenge/forms"
 	"go-google-scraper-challenge/initializers"
 	. "go-google-scraper-challenge/tests/helpers"
@@ -42,7 +43,7 @@ var _ = Describe("Forms/SessionForm", func() {
 
 					Expect(len(formValidation.Errors)).To(Equal(1))
 					Expect(formValidation.Errors[0].Key).To(Equal("Email"))
-					Expect(formValidation.Errors[0].Message).To(Equal("Incorrect email or password"))
+					Expect(formValidation.Errors[0].Message).To(Equal(constants.SignInFail))
 				})
 			})
 
@@ -59,7 +60,7 @@ var _ = Describe("Forms/SessionForm", func() {
 
 					Expect(len(formValidation.Errors)).To(Equal(1))
 					Expect(formValidation.Errors[0].Key).To(Equal("Email"))
-					Expect(formValidation.Errors[0].Message).To(Equal("Incorrect email or password"))
+					Expect(formValidation.Errors[0].Message).To(Equal(constants.SignInFail))
 				})
 			})
 
@@ -76,7 +77,7 @@ var _ = Describe("Forms/SessionForm", func() {
 
 					Expect(len(formValidation.Errors)).To(Equal(1))
 					Expect(formValidation.Errors[0].Key).To(Equal("Password"))
-					Expect(formValidation.Errors[0].Message).To(Equal("Incorrect email or password"))
+					Expect(formValidation.Errors[0].Message).To(Equal(constants.SignInFail))
 				})
 			})
 		})

--- a/forms/session_test.go
+++ b/forms/session_test.go
@@ -93,9 +93,9 @@ var _ = Describe("Forms/SessionForm", func() {
 					Password: password,
 				}
 
-				currentUser, errors := form.Save()
+				currentUser, err := form.Save()
 
-				Expect(len(errors)).To(BeZero())
+				Expect(err).To(BeNil())
 				Expect(currentUser.Id).To(Equal(user.Id))
 			})
 		})
@@ -108,9 +108,9 @@ var _ = Describe("Forms/SessionForm", func() {
 						Password: faker.Password(),
 					}
 
-					user, errors := form.Save()
+					user, err := form.Save()
 
-					Expect(errors[0].Error()).To(Equal("Email must be a valid email address"))
+					Expect(err.Error()).To(Equal("Email must be a valid email address"))
 					Expect(user).To(BeNil())
 				})
 			})
@@ -122,9 +122,9 @@ var _ = Describe("Forms/SessionForm", func() {
 						Password: faker.Password(),
 					}
 
-					user, errors := form.Save()
+					user, err := form.Save()
 
-					Expect(errors[0].Error()).To(Equal("Email must be a valid email address"))
+					Expect(err.Error()).To(Equal("Email can not be empty"))
 					Expect(user).To(BeNil())
 				})
 			})
@@ -136,9 +136,9 @@ var _ = Describe("Forms/SessionForm", func() {
 						Password: "",
 					}
 
-					user, errors := form.Save()
+					user, err := form.Save()
 
-					Expect(errors[0].Error()).To(Equal("Password can not be empty"))
+					Expect(err.Error()).To(Equal("Password can not be empty"))
 					Expect(user).To(BeNil())
 				})
 			})

--- a/forms/upload.go
+++ b/forms/upload.go
@@ -3,6 +3,7 @@ package forms
 import (
 	"mime/multipart"
 
+	"go-google-scraper-challenge/constants"
 	"go-google-scraper-challenge/helpers"
 	"go-google-scraper-challenge/models"
 
@@ -20,7 +21,7 @@ type UploadForm struct {
 // Valid adds custom validation to upload form, sets error when the validation failed.
 func (uf *UploadForm) Valid(v *validation.Validation) {
 	if !uf.validateFilePresence() {
-		err := v.SetError("File", "File cannot be empty")
+		err := v.SetError("File", constants.FileEmpty)
 		if err == nil {
 			logs.Info("Failed to set error on validation")
 		}
@@ -29,7 +30,7 @@ func (uf *UploadForm) Valid(v *validation.Validation) {
 	}
 
 	if !uf.validateFileType() {
-		err := v.SetError("File", "Incorrect file type")
+		err := v.SetError("File", constants.FileTypeInvalid)
 		if err == nil {
 			logs.Info("Failed to set error on validation")
 		}
@@ -38,7 +39,7 @@ func (uf *UploadForm) Valid(v *validation.Validation) {
 	}
 
 	if !uf.validateFileReadability() {
-		err := v.SetError("File", "Unreadable file")
+		err := v.SetError("File", constants.FileUnreadable)
 		if err == nil {
 			logs.Info("Failed to set error on validation")
 		}

--- a/forms/upload.go
+++ b/forms/upload.go
@@ -7,7 +7,6 @@ import (
 	"go-google-scraper-challenge/helpers"
 	"go-google-scraper-challenge/models"
 
-	"github.com/beego/beego/v2/core/logs"
 	"github.com/beego/beego/v2/core/validation"
 )
 
@@ -21,37 +20,25 @@ type UploadForm struct {
 // Valid adds custom validation to upload form, sets error when the validation failed.
 func (uf *UploadForm) Valid(v *validation.Validation) {
 	if !uf.validateFilePresence() {
-		err := v.SetError("File", constants.FileEmpty)
-		if err == nil {
-			logs.Info("Failed to set error on validation")
-		}
+		_ = v.SetError("File", constants.FileEmpty)
 
 		return
 	}
 
 	if !uf.validateFileType() {
-		err := v.SetError("File", constants.FileTypeInvalid)
-		if err == nil {
-			logs.Info("Failed to set error on validation")
-		}
+		_ = v.SetError("File", constants.FileTypeInvalid)
 
 		return
 	}
 
 	if !uf.validateFileReadability() {
-		err := v.SetError("File", constants.FileUnreadable)
-		if err == nil {
-			logs.Info("Failed to set error on validation")
-		}
+		_ = v.SetError("File", constants.FileUnreadable)
 
 		return
 	}
 
 	if !uf.validateKeywordsLength() {
-		err := v.SetError("File", "File should contains between 1 to 1000 keywords")
-		if err == nil {
-			logs.Info("Failed to set error on validation")
-		}
+		_ = v.SetError("File", "File should contains between 1 to 1000 keywords")
 	}
 }
 

--- a/forms/upload_test.go
+++ b/forms/upload_test.go
@@ -1,6 +1,7 @@
 package forms_test
 
 import (
+	"go-google-scraper-challenge/constants"
 	"go-google-scraper-challenge/forms"
 	"go-google-scraper-challenge/initializers"
 	. "go-google-scraper-challenge/tests/helpers"
@@ -43,7 +44,7 @@ var _ = Describe("Forms/UploadForm", func() {
 
 					Expect(len(formValidation.Errors)).To(Equal(1))
 					Expect(formValidation.Errors[0].Key).To(Equal("File"))
-					Expect(formValidation.Errors[0].Message).To(Equal("File cannot be empty"))
+					Expect(formValidation.Errors[0].Message).To(Equal(constants.FileEmpty))
 				})
 			})
 
@@ -62,7 +63,7 @@ var _ = Describe("Forms/UploadForm", func() {
 
 					Expect(len(formValidation.Errors)).To(Equal(1))
 					Expect(formValidation.Errors[0].Key).To(Equal("File"))
-					Expect(formValidation.Errors[0].Message).To(Equal("Incorrect file type"))
+					Expect(formValidation.Errors[0].Message).To(Equal(constants.FileTypeInvalid))
 				})
 			})
 


### PR DESCRIPTION
Resolved #58 

## What happened 👀

- Move error and success messages to constraints
- Remove the error checking after form validation error setting because it's not necessary since the return error is not the error from failed to set error but it's the error that just set by the validation itself
- Adjust all forms to use early return and use only one error from form validation

## Insight 📝

N/A

## Proof Of Work 📹

All test should pass
