### PR TITLE
[#82] As a user I can register via API

### DIFF
--- a/constants/error.go
+++ b/constants/error.go
@@ -1,0 +1,10 @@
+package constants
+
+import "net/http"
+
+var Errors = map[int]string{
+	http.StatusUnauthorized:        "Unauthorized",
+	http.StatusBadRequest:          "Bad Request",
+	http.StatusUnprocessableEntity: "Unprocessable Entity",
+	http.StatusInternalServerError: "Internal Server Error",
+}

--- a/constants/file.go
+++ b/constants/file.go
@@ -1,0 +1,9 @@
+package constants
+
+const (
+	FileEmpty         = "File cannot be empty"
+	FileTypeInvalid   = "Incorrect file type"
+	FileUnreadable    = "Unreadable file"
+	FileUploadFail    = "Failed to upload file, please make sure the file is not corrupted"
+	FileUploadSuccess = "Successfully uploaded the file, the result status would be updated soon"
+)

--- a/constants/oauth.go
+++ b/constants/oauth.go
@@ -1,0 +1,6 @@
+package constants
+
+const (
+	OAuthClientCreateSuccess = "The Client was successfully created"
+	OAuthClientInvalid       = "Authentication client is invalid"
+)

--- a/constants/registration.go
+++ b/constants/registration.go
@@ -1,0 +1,6 @@
+package constants
+
+const (
+	UserAlreadyExist        = "User with this email already exist"
+	PasswordConfirmNotMatch = "Password confirmation must match the password"
+)

--- a/constants/session.go
+++ b/constants/session.go
@@ -1,0 +1,8 @@
+package constants
+
+const (
+	SignInFail     = "Incorrect email or password"
+	SignInSuccess  = "Successfully signed in"
+	SignOutFail    = "Failed to sign out"
+	SignOutSuccess = "Successfully signed out"
+)

--- a/constants/user.go
+++ b/constants/user.go
@@ -1,0 +1,5 @@
+package constants
+
+const (
+	UserCreateSuccess = "The user was successfully created"
+)

--- a/helpers/api/error.go
+++ b/helpers/api/error.go
@@ -1,7 +1,7 @@
 package api_helpers
 
 import (
-	"fmt"
+	"go-google-scraper-challenge/constants"
 	"go-google-scraper-challenge/lib/api/v1/serializers"
 
 	"github.com/gin-gonic/gin"
@@ -9,7 +9,7 @@ import (
 
 func ResponseWithError(ctx *gin.Context, code int, err error) {
 	errorResponse := serializers.ErrorResponse{
-		Error:       fmt.Sprint(code),
+		Error:       constants.Errors[code],
 		ErrorDetail: err.Error(),
 	}
 

--- a/helpers/api/error.go
+++ b/helpers/api/error.go
@@ -9,8 +9,8 @@ import (
 
 func ResponseWithError(ctx *gin.Context, code int, err error) {
 	errorResponse := serializers.ErrorResponse{
-		Error:       constants.Errors[code],
-		ErrorDetail: err.Error(),
+		Error:            constants.Errors[code],
+		ErrorDescription: err.Error(),
 	}
 
 	ctx.JSON(code, errorResponse)

--- a/helpers/api/error.go
+++ b/helpers/api/error.go
@@ -1,8 +1,6 @@
 package helpers
 
 import (
-  "fmt"
-
 	"go-google-scraper-challenge/constants"
 	"go-google-scraper-challenge/lib/api/v1/serializers"
 

--- a/lib/api/v1/controllers/users.go
+++ b/lib/api/v1/controllers/users.go
@@ -25,13 +25,13 @@ func (c *UsersController) Register(ctx *gin.Context) {
 
 	err := ctx.ShouldBindWith(registrationForm, binding.Form)
 	if err != nil {
-		ResponseWithError(ctx, http.StatusUnprocessableEntity, err)
+		ResponseWithError(ctx, http.StatusBadRequest, err)
 		return
 	}
 
 	_, err = registrationForm.Validate()
 	if err != nil {
-		ResponseWithError(ctx, http.StatusUnprocessableEntity, err)
+		ResponseWithError(ctx, http.StatusBadRequest, err)
 		return
 	}
 

--- a/lib/api/v1/controllers/users.go
+++ b/lib/api/v1/controllers/users.go
@@ -1,0 +1,64 @@
+package controllers
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+
+	"go-google-scraper-challenge/constants"
+	. "go-google-scraper-challenge/helpers/api"
+	"go-google-scraper-challenge/lib/api/v1/forms"
+	"go-google-scraper-challenge/lib/api/v1/serializers"
+	"go-google-scraper-challenge/lib/models"
+	"go-google-scraper-challenge/lib/services/oauth"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/binding"
+)
+
+type UsersController struct {
+	BaseController
+}
+
+func (c *UsersController) Register(ctx *gin.Context) {
+	registrationForm := &forms.RegistrationForm{}
+
+	err := ctx.ShouldBindWith(registrationForm, binding.Form)
+	if err != nil {
+		ResponseWithError(ctx, http.StatusUnprocessableEntity, err)
+		return
+	}
+
+	_, err = registrationForm.Validate()
+	if err != nil {
+		ResponseWithError(ctx, http.StatusUnprocessableEntity, err)
+		return
+	}
+
+	userID, err := registrationForm.Save()
+	if err != nil {
+		ResponseWithError(ctx, http.StatusUnprocessableEntity, err)
+		return
+	}
+
+	tokenRequest := &oauth.TokenRequest{
+		ClientID:     registrationForm.ClientID,
+		ClientSecret: registrationForm.ClientSecret,
+		UserID:       fmt.Sprint(userID),
+	}
+
+	tokenInfo, err := oauth.GenerateToken(tokenRequest)
+	if err != nil {
+		_ = models.DeleteUser(userID)
+		ResponseWithError(ctx, http.StatusUnauthorized, errors.New(constants.OAuthClientInvalid))
+		return
+	}
+
+	response := serializers.RegistrationResponse{
+		UserID:       userID,
+		AccessToken:  tokenInfo.GetAccess(),
+		RefreshToken: tokenInfo.GetRefresh(),
+	}
+
+	ctx.JSON(http.StatusOK, response)
+}

--- a/lib/api/v1/controllers/users_test.go
+++ b/lib/api/v1/controllers/users_test.go
@@ -58,9 +58,9 @@ var _ = Describe("UsersController", func() {
 			})
 		})
 
-		Context("given invalid params", func() {
-			Context("client id", func() {
-				Context("given no client id", func() {
+		Context("given INVALID params", func() {
+			Context("client ID", func() {
+				Context("given NO client ID", func() {
 					It("response with the error status", func() {
 						authClient := FabricateAuthClient()
 						formData := url.Values{
@@ -75,7 +75,7 @@ var _ = Describe("UsersController", func() {
 						usersController := controllers.UsersController{}
 						usersController.Register(ctx)
 
-						Expect(response.Code).To(Equal(http.StatusUnprocessableEntity))
+						Expect(response.Code).To(Equal(http.StatusBadRequest))
 					})
 
 					It("response with the error detail", func() {
@@ -95,12 +95,12 @@ var _ = Describe("UsersController", func() {
 						jsonResponse := serializers.ErrorResponse{}
 						test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
-						Expect(jsonResponse.Error).To(Equal(http.StatusUnprocessableEntity))
+						Expect(jsonResponse.Error).To(Equal(constants.Errors[http.StatusBadRequest]))
 						Expect(jsonResponse.ErrorDetail).To(Equal("ClientID: cannot be blank."))
 					})
 				})
 
-				Context("given invalid client id", func() {
+				Context("given INVALID client ID", func() {
 					It("response with the error status", func() {
 						authClient := FabricateAuthClient()
 						formData := url.Values{
@@ -135,14 +135,14 @@ var _ = Describe("UsersController", func() {
 						jsonResponse := serializers.ErrorResponse{}
 						test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
-						Expect(jsonResponse.Error).To(Equal(http.StatusUnauthorized))
+						Expect(jsonResponse.Error).To(Equal(constants.Errors[http.StatusUnauthorized]))
 						Expect(jsonResponse.ErrorDetail).To(Equal(constants.OAuthClientInvalid))
 					})
 				})
 			})
 
 			Context("client secret", func() {
-				Context("given no client secret", func() {
+				Context("given NO client secret", func() {
 					It("response with the error status", func() {
 						authClient := FabricateAuthClient()
 						formData := url.Values{
@@ -157,7 +157,7 @@ var _ = Describe("UsersController", func() {
 						usersController := controllers.UsersController{}
 						usersController.Register(ctx)
 
-						Expect(response.Code).To(Equal(http.StatusUnprocessableEntity))
+						Expect(response.Code).To(Equal(http.StatusBadRequest))
 					})
 
 					It("response with the error detail", func() {
@@ -177,12 +177,12 @@ var _ = Describe("UsersController", func() {
 						jsonResponse := serializers.ErrorResponse{}
 						test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
-						Expect(jsonResponse.Error).To(Equal(http.StatusUnprocessableEntity))
+						Expect(jsonResponse.Error).To(Equal(constants.Errors[http.StatusBadRequest]))
 						Expect(jsonResponse.ErrorDetail).To(Equal("ClientSecret: cannot be blank."))
 					})
 				})
 
-				Context("given invalid client secret", func() {
+				Context("given INVALID client secret", func() {
 					It("response with the error status", func() {
 						authClient := FabricateAuthClient()
 						formData := url.Values{
@@ -217,14 +217,14 @@ var _ = Describe("UsersController", func() {
 						jsonResponse := serializers.ErrorResponse{}
 						test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
-						Expect(jsonResponse.Error).To(Equal(http.StatusUnauthorized))
+						Expect(jsonResponse.Error).To(Equal(constants.Errors[http.StatusUnauthorized]))
 						Expect(jsonResponse.ErrorDetail).To(Equal(constants.OAuthClientInvalid))
 					})
 				})
 			})
 
 			Context("email", func() {
-				Context("given no email", func() {
+				Context("given NO email", func() {
 					It("responses with the error status", func() {
 						authClient := FabricateAuthClient()
 						formData := url.Values{
@@ -239,7 +239,7 @@ var _ = Describe("UsersController", func() {
 						usersController := controllers.UsersController{}
 						usersController.Register(ctx)
 
-						Expect(response.Code).To(Equal(http.StatusUnprocessableEntity))
+						Expect(response.Code).To(Equal(http.StatusBadRequest))
 					})
 
 					It("responses with the error detail", func() {
@@ -259,12 +259,12 @@ var _ = Describe("UsersController", func() {
 						jsonResponse := serializers.ErrorResponse{}
 						test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
-						Expect(jsonResponse.Error).To(Equal(http.StatusUnprocessableEntity))
+						Expect(jsonResponse.Error).To(Equal(constants.Errors[http.StatusBadRequest]))
 						Expect(jsonResponse.ErrorDetail).To(Equal("Email: cannot be blank."))
 					})
 				})
 
-				Context("given an invalid email", func() {
+				Context("given an INVALID email", func() {
 					It("responses with the error status", func() {
 						authClient := FabricateAuthClient()
 						formData := url.Values{
@@ -279,7 +279,7 @@ var _ = Describe("UsersController", func() {
 						usersController := controllers.UsersController{}
 						usersController.Register(ctx)
 
-						Expect(response.Code).To(Equal(http.StatusUnprocessableEntity))
+						Expect(response.Code).To(Equal(http.StatusBadRequest))
 					})
 
 					It("responses with the error detail", func() {
@@ -299,14 +299,14 @@ var _ = Describe("UsersController", func() {
 						jsonResponse := serializers.ErrorResponse{}
 						test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
-						Expect(jsonResponse.Error).To(Equal(http.StatusUnprocessableEntity))
+						Expect(jsonResponse.Error).To(Equal(constants.Errors[http.StatusBadRequest]))
 						Expect(jsonResponse.ErrorDetail).To(Equal("Email: must be a valid email address."))
 					})
 				})
 			})
 
 			Context("password", func() {
-				Context("given no password", func() {
+				Context("given NO password", func() {
 					It("responses with the error status", func() {
 						authClient := FabricateAuthClient()
 						formData := url.Values{
@@ -321,7 +321,7 @@ var _ = Describe("UsersController", func() {
 						usersController := controllers.UsersController{}
 						usersController.Register(ctx)
 
-						Expect(response.Code).To(Equal(http.StatusUnprocessableEntity))
+						Expect(response.Code).To(Equal(http.StatusBadRequest))
 					})
 
 					It("responses with the error detail", func() {
@@ -341,7 +341,7 @@ var _ = Describe("UsersController", func() {
 						jsonResponse := serializers.ErrorResponse{}
 						test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
-						Expect(jsonResponse.Error).To(Equal(http.StatusUnprocessableEntity))
+						Expect(jsonResponse.Error).To(Equal(constants.Errors[http.StatusBadRequest]))
 						Expect(jsonResponse.ErrorDetail).To(Equal("Password: cannot be blank."))
 					})
 				})
@@ -361,7 +361,7 @@ var _ = Describe("UsersController", func() {
 						usersController := controllers.UsersController{}
 						usersController.Register(ctx)
 
-						Expect(response.Code).To(Equal(http.StatusUnprocessableEntity))
+						Expect(response.Code).To(Equal(http.StatusBadRequest))
 					})
 
 					It("responses with the error detail", func() {
@@ -381,7 +381,7 @@ var _ = Describe("UsersController", func() {
 						jsonResponse := serializers.ErrorResponse{}
 						test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
-						Expect(jsonResponse.Error).To(Equal(http.StatusUnprocessableEntity))
+						Expect(jsonResponse.Error).To(Equal(constants.Errors[http.StatusBadRequest]))
 						Expect(jsonResponse.ErrorDetail).To(Equal("Password: the length must be between 6 and 50."))
 					})
 				})

--- a/lib/api/v1/controllers/users_test.go
+++ b/lib/api/v1/controllers/users_test.go
@@ -96,7 +96,7 @@ var _ = Describe("UsersController", func() {
 						test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
 						Expect(jsonResponse.Error).To(Equal(constants.Errors[http.StatusBadRequest]))
-						Expect(jsonResponse.ErrorDetail).To(Equal("ClientID: cannot be blank."))
+						Expect(jsonResponse.ErrorDescription).To(Equal("ClientID: cannot be blank."))
 					})
 				})
 
@@ -136,7 +136,7 @@ var _ = Describe("UsersController", func() {
 						test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
 						Expect(jsonResponse.Error).To(Equal(constants.Errors[http.StatusUnauthorized]))
-						Expect(jsonResponse.ErrorDetail).To(Equal(constants.OAuthClientInvalid))
+						Expect(jsonResponse.ErrorDescription).To(Equal(constants.OAuthClientInvalid))
 					})
 				})
 			})
@@ -178,7 +178,7 @@ var _ = Describe("UsersController", func() {
 						test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
 						Expect(jsonResponse.Error).To(Equal(constants.Errors[http.StatusBadRequest]))
-						Expect(jsonResponse.ErrorDetail).To(Equal("ClientSecret: cannot be blank."))
+						Expect(jsonResponse.ErrorDescription).To(Equal("ClientSecret: cannot be blank."))
 					})
 				})
 
@@ -218,7 +218,7 @@ var _ = Describe("UsersController", func() {
 						test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
 						Expect(jsonResponse.Error).To(Equal(constants.Errors[http.StatusUnauthorized]))
-						Expect(jsonResponse.ErrorDetail).To(Equal(constants.OAuthClientInvalid))
+						Expect(jsonResponse.ErrorDescription).To(Equal(constants.OAuthClientInvalid))
 					})
 				})
 			})
@@ -260,7 +260,7 @@ var _ = Describe("UsersController", func() {
 						test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
 						Expect(jsonResponse.Error).To(Equal(constants.Errors[http.StatusBadRequest]))
-						Expect(jsonResponse.ErrorDetail).To(Equal("Email: cannot be blank."))
+						Expect(jsonResponse.ErrorDescription).To(Equal("Email: cannot be blank."))
 					})
 				})
 
@@ -300,7 +300,7 @@ var _ = Describe("UsersController", func() {
 						test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
 						Expect(jsonResponse.Error).To(Equal(constants.Errors[http.StatusBadRequest]))
-						Expect(jsonResponse.ErrorDetail).To(Equal("Email: must be a valid email address."))
+						Expect(jsonResponse.ErrorDescription).To(Equal("Email: must be a valid email address."))
 					})
 				})
 			})
@@ -342,7 +342,7 @@ var _ = Describe("UsersController", func() {
 						test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
 						Expect(jsonResponse.Error).To(Equal(constants.Errors[http.StatusBadRequest]))
-						Expect(jsonResponse.ErrorDetail).To(Equal("Password: cannot be blank."))
+						Expect(jsonResponse.ErrorDescription).To(Equal("Password: cannot be blank."))
 					})
 				})
 
@@ -382,7 +382,7 @@ var _ = Describe("UsersController", func() {
 						test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
 						Expect(jsonResponse.Error).To(Equal(constants.Errors[http.StatusBadRequest]))
-						Expect(jsonResponse.ErrorDetail).To(Equal("Password: the length must be between 6 and 50."))
+						Expect(jsonResponse.ErrorDescription).To(Equal("Password: the length must be between 6 and 50."))
 					})
 				})
 			})

--- a/lib/api/v1/controllers/users_test.go
+++ b/lib/api/v1/controllers/users_test.go
@@ -388,4 +388,8 @@ var _ = Describe("UsersController", func() {
 			})
 		})
 	})
+
+	AfterEach(func() {
+		CleanupDatabase([]string{"users", "oauth2_clients", "oauth2_tokens"})
+	})
 })

--- a/lib/api/v1/controllers/users_test.go
+++ b/lib/api/v1/controllers/users_test.go
@@ -1,0 +1,391 @@
+package controllers_test
+
+import (
+	"net/http"
+	"net/url"
+
+	"go-google-scraper-challenge/constants"
+	"go-google-scraper-challenge/lib/api/v1/controllers"
+	"go-google-scraper-challenge/lib/api/v1/serializers"
+	"go-google-scraper-challenge/test"
+	. "go-google-scraper-challenge/test"
+
+	"github.com/bxcodec/faker/v3"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("UsersController", func() {
+	Describe("POST /register", func() {
+		Context("given valid params", func() {
+			It("responses with status OK", func() {
+				authClient := FabricateAuthClient()
+				formData := url.Values{
+					"username":      {faker.Email()},
+					"password":      {faker.Password()},
+					"client_id":     {authClient.ClientID},
+					"client_secret": {authClient.ClientSecret},
+				}
+
+				ctx, response := MakeFormRequest("POST", "/register", formData)
+
+				usersController := controllers.UsersController{}
+				usersController.Register(ctx)
+
+				Expect(response.Code).To(Equal(http.StatusOK))
+			})
+
+			It("responses with the user information", func() {
+				authClient := FabricateAuthClient()
+				formData := url.Values{
+					"username":      {faker.Email()},
+					"password":      {faker.Password()},
+					"client_id":     {authClient.ClientID},
+					"client_secret": {authClient.ClientSecret},
+				}
+
+				ctx, response := MakeFormRequest("POST", "/register", formData)
+
+				usersController := controllers.UsersController{}
+				usersController.Register(ctx)
+
+				jsonResponse := serializers.RegistrationResponse{}
+				test.GetJSONResponseBody(response.Result(), &jsonResponse)
+
+				Expect(jsonResponse.UserID).To(BeNumerically(">", 0))
+				Expect(jsonResponse.AccessToken).NotTo(Equal(""))
+				Expect(jsonResponse.RefreshToken).NotTo(Equal(""))
+			})
+		})
+
+		Context("given invalid params", func() {
+			Context("client id", func() {
+				Context("given no client id", func() {
+					It("response with the error status", func() {
+						authClient := FabricateAuthClient()
+						formData := url.Values{
+							"username":      {faker.Email()},
+							"password":      {faker.Password()},
+							"client_id":     {""},
+							"client_secret": {authClient.ClientSecret},
+						}
+
+						ctx, response := MakeFormRequest("POST", "/register", formData)
+
+						usersController := controllers.UsersController{}
+						usersController.Register(ctx)
+
+						Expect(response.Code).To(Equal(http.StatusUnprocessableEntity))
+					})
+
+					It("response with the error detail", func() {
+						authClient := FabricateAuthClient()
+						formData := url.Values{
+							"username":      {faker.Email()},
+							"password":      {faker.Password()},
+							"client_id":     {""},
+							"client_secret": {authClient.ClientSecret},
+						}
+
+						ctx, response := MakeFormRequest("POST", "/register", formData)
+
+						usersController := controllers.UsersController{}
+						usersController.Register(ctx)
+
+						jsonResponse := serializers.ErrorResponse{}
+						test.GetJSONResponseBody(response.Result(), &jsonResponse)
+
+						Expect(jsonResponse.Error).To(Equal(http.StatusUnprocessableEntity))
+						Expect(jsonResponse.ErrorDetail).To(Equal("ClientID: cannot be blank."))
+					})
+				})
+
+				Context("given invalid client id", func() {
+					It("response with the error status", func() {
+						authClient := FabricateAuthClient()
+						formData := url.Values{
+							"username":      {faker.Email()},
+							"password":      {faker.Password()},
+							"client_id":     {"invalid_id"},
+							"client_secret": {authClient.ClientSecret},
+						}
+
+						ctx, response := MakeFormRequest("POST", "/register", formData)
+
+						usersController := controllers.UsersController{}
+						usersController.Register(ctx)
+
+						Expect(response.Code).To(Equal(http.StatusUnauthorized))
+					})
+
+					It("response with the error detail", func() {
+						authClient := FabricateAuthClient()
+						formData := url.Values{
+							"username":      {faker.Email()},
+							"password":      {faker.Password()},
+							"client_id":     {"invalid_id"},
+							"client_secret": {authClient.ClientSecret},
+						}
+
+						ctx, response := MakeFormRequest("POST", "/register", formData)
+
+						usersController := controllers.UsersController{}
+						usersController.Register(ctx)
+
+						jsonResponse := serializers.ErrorResponse{}
+						test.GetJSONResponseBody(response.Result(), &jsonResponse)
+
+						Expect(jsonResponse.Error).To(Equal(http.StatusUnauthorized))
+						Expect(jsonResponse.ErrorDetail).To(Equal(constants.OAuthClientInvalid))
+					})
+				})
+			})
+
+			Context("client secret", func() {
+				Context("given no client secret", func() {
+					It("response with the error status", func() {
+						authClient := FabricateAuthClient()
+						formData := url.Values{
+							"username":      {faker.Email()},
+							"password":      {faker.Password()},
+							"client_id":     {authClient.ClientID},
+							"client_secret": {""},
+						}
+
+						ctx, response := MakeFormRequest("POST", "/register", formData)
+
+						usersController := controllers.UsersController{}
+						usersController.Register(ctx)
+
+						Expect(response.Code).To(Equal(http.StatusUnprocessableEntity))
+					})
+
+					It("response with the error detail", func() {
+						authClient := FabricateAuthClient()
+						formData := url.Values{
+							"username":      {faker.Email()},
+							"password":      {faker.Password()},
+							"client_id":     {authClient.ClientID},
+							"client_secret": {""},
+						}
+
+						ctx, response := MakeFormRequest("POST", "/register", formData)
+
+						usersController := controllers.UsersController{}
+						usersController.Register(ctx)
+
+						jsonResponse := serializers.ErrorResponse{}
+						test.GetJSONResponseBody(response.Result(), &jsonResponse)
+
+						Expect(jsonResponse.Error).To(Equal(http.StatusUnprocessableEntity))
+						Expect(jsonResponse.ErrorDetail).To(Equal("ClientSecret: cannot be blank."))
+					})
+				})
+
+				Context("given invalid client secret", func() {
+					It("response with the error status", func() {
+						authClient := FabricateAuthClient()
+						formData := url.Values{
+							"username":      {faker.Email()},
+							"password":      {faker.Password()},
+							"client_id":     {authClient.ClientID},
+							"client_secret": {"invalid secret"},
+						}
+
+						ctx, response := MakeFormRequest("POST", "/register", formData)
+
+						usersController := controllers.UsersController{}
+						usersController.Register(ctx)
+
+						Expect(response.Code).To(Equal(http.StatusUnauthorized))
+					})
+
+					It("response with the error detail", func() {
+						authClient := FabricateAuthClient()
+						formData := url.Values{
+							"username":      {faker.Email()},
+							"password":      {faker.Password()},
+							"client_id":     {authClient.ClientID},
+							"client_secret": {"invalid secret"},
+						}
+
+						ctx, response := MakeFormRequest("POST", "/register", formData)
+
+						usersController := controllers.UsersController{}
+						usersController.Register(ctx)
+
+						jsonResponse := serializers.ErrorResponse{}
+						test.GetJSONResponseBody(response.Result(), &jsonResponse)
+
+						Expect(jsonResponse.Error).To(Equal(http.StatusUnauthorized))
+						Expect(jsonResponse.ErrorDetail).To(Equal(constants.OAuthClientInvalid))
+					})
+				})
+			})
+
+			Context("email", func() {
+				Context("given no email", func() {
+					It("responses with the error status", func() {
+						authClient := FabricateAuthClient()
+						formData := url.Values{
+							"username":      {""},
+							"password":      {faker.Password()},
+							"client_id":     {authClient.ClientID},
+							"client_secret": {authClient.ClientSecret},
+						}
+
+						ctx, response := MakeFormRequest("POST", "/register", formData)
+
+						usersController := controllers.UsersController{}
+						usersController.Register(ctx)
+
+						Expect(response.Code).To(Equal(http.StatusUnprocessableEntity))
+					})
+
+					It("responses with the error detail", func() {
+						authClient := FabricateAuthClient()
+						formData := url.Values{
+							"username":      {""},
+							"password":      {faker.Password()},
+							"client_id":     {authClient.ClientID},
+							"client_secret": {authClient.ClientSecret},
+						}
+
+						ctx, response := MakeFormRequest("POST", "/register", formData)
+
+						usersController := controllers.UsersController{}
+						usersController.Register(ctx)
+
+						jsonResponse := serializers.ErrorResponse{}
+						test.GetJSONResponseBody(response.Result(), &jsonResponse)
+
+						Expect(jsonResponse.Error).To(Equal(http.StatusUnprocessableEntity))
+						Expect(jsonResponse.ErrorDetail).To(Equal("Email: cannot be blank."))
+					})
+				})
+
+				Context("given an invalid email", func() {
+					It("responses with the error status", func() {
+						authClient := FabricateAuthClient()
+						formData := url.Values{
+							"username":      {"invalid email"},
+							"password":      {faker.Password()},
+							"client_id":     {authClient.ClientID},
+							"client_secret": {authClient.ClientSecret},
+						}
+
+						ctx, response := MakeFormRequest("POST", "/register", formData)
+
+						usersController := controllers.UsersController{}
+						usersController.Register(ctx)
+
+						Expect(response.Code).To(Equal(http.StatusUnprocessableEntity))
+					})
+
+					It("responses with the error detail", func() {
+						authClient := FabricateAuthClient()
+						formData := url.Values{
+							"username":      {"invalid email"},
+							"password":      {faker.Password()},
+							"client_id":     {authClient.ClientID},
+							"client_secret": {authClient.ClientSecret},
+						}
+
+						ctx, response := MakeFormRequest("POST", "/register", formData)
+
+						usersController := controllers.UsersController{}
+						usersController.Register(ctx)
+
+						jsonResponse := serializers.ErrorResponse{}
+						test.GetJSONResponseBody(response.Result(), &jsonResponse)
+
+						Expect(jsonResponse.Error).To(Equal(http.StatusUnprocessableEntity))
+						Expect(jsonResponse.ErrorDetail).To(Equal("Email: must be a valid email address."))
+					})
+				})
+			})
+
+			Context("password", func() {
+				Context("given no password", func() {
+					It("responses with the error status", func() {
+						authClient := FabricateAuthClient()
+						formData := url.Values{
+							"username":      {faker.Email()},
+							"password":      {""},
+							"client_id":     {authClient.ClientID},
+							"client_secret": {authClient.ClientSecret},
+						}
+
+						ctx, response := MakeFormRequest("POST", "/register", formData)
+
+						usersController := controllers.UsersController{}
+						usersController.Register(ctx)
+
+						Expect(response.Code).To(Equal(http.StatusUnprocessableEntity))
+					})
+
+					It("responses with the error detail", func() {
+						authClient := FabricateAuthClient()
+						formData := url.Values{
+							"username":      {faker.Email()},
+							"password":      {""},
+							"client_id":     {authClient.ClientID},
+							"client_secret": {authClient.ClientSecret},
+						}
+
+						ctx, response := MakeFormRequest("POST", "/register", formData)
+
+						usersController := controllers.UsersController{}
+						usersController.Register(ctx)
+
+						jsonResponse := serializers.ErrorResponse{}
+						test.GetJSONResponseBody(response.Result(), &jsonResponse)
+
+						Expect(jsonResponse.Error).To(Equal(http.StatusUnprocessableEntity))
+						Expect(jsonResponse.ErrorDetail).To(Equal("Password: cannot be blank."))
+					})
+				})
+
+				Context("given password is shorter than 6 charactors", func() {
+					It("responses with the error status", func() {
+						authClient := FabricateAuthClient()
+						formData := url.Values{
+							"username":      {faker.Email()},
+							"password":      {"short"},
+							"client_id":     {authClient.ClientID},
+							"client_secret": {authClient.ClientSecret},
+						}
+
+						ctx, response := MakeFormRequest("POST", "/register", formData)
+
+						usersController := controllers.UsersController{}
+						usersController.Register(ctx)
+
+						Expect(response.Code).To(Equal(http.StatusUnprocessableEntity))
+					})
+
+					It("responses with the error detail", func() {
+						authClient := FabricateAuthClient()
+						formData := url.Values{
+							"username":      {faker.Email()},
+							"password":      {"short"},
+							"client_id":     {authClient.ClientID},
+							"client_secret": {authClient.ClientSecret},
+						}
+
+						ctx, response := MakeFormRequest("POST", "/register", formData)
+
+						usersController := controllers.UsersController{}
+						usersController.Register(ctx)
+
+						jsonResponse := serializers.ErrorResponse{}
+						test.GetJSONResponseBody(response.Result(), &jsonResponse)
+
+						Expect(jsonResponse.Error).To(Equal(http.StatusUnprocessableEntity))
+						Expect(jsonResponse.ErrorDetail).To(Equal("Password: the length must be between 6 and 50."))
+					})
+				})
+			})
+		})
+	})
+})

--- a/lib/api/v1/forms/forms_suite_test.go
+++ b/lib/api/v1/forms/forms_suite_test.go
@@ -1,0 +1,19 @@
+package forms_test
+
+import (
+	"testing"
+
+	"go-google-scraper-challenge/test"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestForms(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Forms Suite")
+}
+
+var _ = BeforeSuite(func() {
+	test.SetupTestEnvironment()
+})

--- a/lib/api/v1/forms/registration.go
+++ b/lib/api/v1/forms/registration.go
@@ -1,0 +1,65 @@
+package forms
+
+import (
+	"errors"
+
+	"go-google-scraper-challenge/constants"
+	"go-google-scraper-challenge/helpers"
+	"go-google-scraper-challenge/lib/models"
+
+	validation "github.com/go-ozzo/ozzo-validation"
+	"github.com/go-ozzo/ozzo-validation/is"
+)
+
+type RegistrationForm struct {
+	ClientID     string `form:"client_id"`
+	ClientSecret string `form:"client_secret"`
+	Email        string `form:"username"`
+	Password     string `form:"password"`
+}
+
+func (f RegistrationForm) Validate() (valid bool, err error) {
+	err = validation.ValidateStruct(&f,
+		validation.Field(&f.ClientID, validation.Required),
+		validation.Field(&f.ClientSecret, validation.Required),
+		validation.Field(&f.Email, validation.Required, is.Email),
+		validation.Field(&f.Password, validation.Required, validation.Length(6, 50)),
+	)
+
+	if err != nil {
+		return false, err
+	}
+
+	emailAlreadyExisted := models.UserEmailAlreadyExisted(f.Email)
+	if emailAlreadyExisted {
+		return false, errors.New(constants.UserAlreadyExist)
+	}
+
+	return true, nil
+}
+
+// Save validates registration form and adds a new User with email and password from the form,
+// returns errors if validation failed or cannot add the user to database.
+func (f RegistrationForm) Save() (int64, error) {
+	_, err := f.Validate()
+	if err != nil {
+		return -1, err
+	}
+
+	hashedPassword, err := helpers.HashPassword(f.Password)
+	if err != nil {
+		return -1, err
+	}
+
+	user := &models.User{
+		Email:          f.Email,
+		HashedPassword: hashedPassword,
+	}
+
+	userID, err := models.CreateUser(user)
+	if err != nil {
+		return -1, err
+	}
+
+	return userID, nil
+}

--- a/lib/api/v1/forms/registration_test.go
+++ b/lib/api/v1/forms/registration_test.go
@@ -1,0 +1,188 @@
+package forms_test
+
+import (
+	"go-google-scraper-challenge/constants"
+	"go-google-scraper-challenge/lib/api/v1/forms"
+	"go-google-scraper-challenge/lib/models"
+	. "go-google-scraper-challenge/test"
+
+	"github.com/bxcodec/faker/v3"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("API Registration Form", func() {
+	Describe("#Save", func() {
+		Context("given registration form with valid params", func() {
+			It("returns a user ID", func() {
+				authClient := FabricateAuthClient()
+				form := forms.RegistrationForm{
+					ClientID:     authClient.ClientID,
+					ClientSecret: authClient.ClientSecret,
+					Email:        faker.Email(),
+					Password:     faker.Password(),
+				}
+
+				userID, err := form.Save()
+				if err != nil {
+					Fail("Failed to save form")
+				}
+
+				Expect(userID).To(BeNumerically(">", 0))
+
+				user, err := models.GetUserByID(userID)
+				if err != nil {
+					Fail("Failed to find the user")
+				}
+
+				Expect(user.Email).To(Equal(form.Email))
+			})
+
+			It("returns NO error", func() {
+				authClient := FabricateAuthClient()
+				form := forms.RegistrationForm{
+					ClientID:     authClient.ClientID,
+					ClientSecret: authClient.ClientSecret,
+					Email:        faker.Email(),
+					Password:     faker.Password(),
+				}
+
+				_, err := form.Save()
+
+				Expect(err).To(BeNil())
+			})
+		})
+
+		Context("given registration form with INVALID params", func() {
+			Context("authentication client", func() {
+				Context("given NO client id", func() {
+					It("returns an INVALID client ID error", func() {
+						authClient := FabricateAuthClient()
+						form := forms.RegistrationForm{
+							ClientID:     "",
+							ClientSecret: authClient.ClientSecret,
+							Email:        faker.Email(),
+							Password:     faker.Password(),
+						}
+
+						userID, err := form.Save()
+
+						Expect(userID).To(BeNumerically("==", -1))
+						Expect(err.Error()).To(Equal("ClientID: cannot be blank."))
+					})
+				})
+
+				Context("given NO client secret", func() {
+					It("returns an INVALID client ID error", func() {
+						authClient := FabricateAuthClient()
+						form := forms.RegistrationForm{
+							ClientID:     authClient.ClientID,
+							ClientSecret: "",
+							Email:        faker.Email(),
+							Password:     faker.Password(),
+						}
+
+						userID, err := form.Save()
+
+						Expect(userID).To(BeNumerically("==", -1))
+						Expect(err.Error()).To(Equal("ClientSecret: cannot be blank."))
+					})
+				})
+			})
+
+			Context("email", func() {
+				Context("given email that already registered", func() {
+					It("returns a duplicate email error", func() {
+						user := FabricateUser(faker.Email(), faker.Password())
+						authClient := FabricateAuthClient()
+						form := forms.RegistrationForm{
+							ClientID:     authClient.ClientID,
+							ClientSecret: authClient.ClientSecret,
+							Email:        user.Email,
+							Password:     faker.Password(),
+						}
+
+						userID, err := form.Save()
+
+						Expect(userID).To(BeNumerically("==", -1))
+						Expect(err.Error()).To(Equal(constants.UserAlreadyExist))
+					})
+				})
+
+				Context("given NO email", func() {
+					It("returns an INVALID email error", func() {
+						authClient := FabricateAuthClient()
+						form := forms.RegistrationForm{
+							ClientID:     authClient.ClientID,
+							ClientSecret: authClient.ClientSecret,
+							Email:        "",
+							Password:     faker.Password(),
+						}
+
+						userID, err := form.Save()
+
+						Expect(userID).To(BeNumerically("==", -1))
+						Expect(err.Error()).To(Equal("Email: cannot be blank."))
+					})
+				})
+
+				Context("given an INVALID email", func() {
+					It("returns an INVALID email error", func() {
+						authClient := FabricateAuthClient()
+						form := forms.RegistrationForm{
+							ClientID:     authClient.ClientID,
+							ClientSecret: authClient.ClientSecret,
+							Email:        "invalid",
+							Password:     faker.Password(),
+						}
+
+						userID, err := form.Save()
+
+						Expect(userID).To(BeNumerically("==", -1))
+						Expect(err.Error()).To(Equal("Email: must be a valid email address."))
+					})
+				})
+			})
+
+			Context("password", func() {
+				Context("given NO password", func() {
+					It("returns an INVALID password error", func() {
+						authClient := FabricateAuthClient()
+						form := forms.RegistrationForm{
+							ClientID:     authClient.ClientID,
+							ClientSecret: authClient.ClientSecret,
+							Email:        faker.Email(),
+							Password:     "",
+						}
+
+						userID, err := form.Save()
+
+						Expect(userID).To(BeNumerically("==", -1))
+						Expect(err.Error()).To(Equal("Password: cannot be blank."))
+					})
+				})
+
+				Context("given password length is less than 6", func() {
+					It("returns an INVALID password error", func() {
+						authClient := FabricateAuthClient()
+						form := forms.RegistrationForm{
+							ClientID:     authClient.ClientID,
+							ClientSecret: authClient.ClientSecret,
+							Email:        faker.Email(),
+							Password:     "1234",
+						}
+
+						userID, err := form.Save()
+
+						Expect(userID).To(BeNumerically("==", -1))
+						Expect(err.Error()).To(Equal("Password: the length must be between 6 and 50."))
+					})
+				})
+			})
+		})
+	})
+
+	AfterEach(func() {
+		CleanupDatabase([]string{"users"})
+	})
+})

--- a/lib/api/v1/forms/registration_test.go
+++ b/lib/api/v1/forms/registration_test.go
@@ -183,6 +183,6 @@ var _ = Describe("API Registration Form", func() {
 	})
 
 	AfterEach(func() {
-		CleanupDatabase([]string{"users"})
+		CleanupDatabase([]string{"users", "oauth2_clients", "oauth2_tokens"})
 	})
 })

--- a/lib/api/v1/routers/router.go
+++ b/lib/api/v1/routers/router.go
@@ -12,7 +12,9 @@ func ComebineRoutes(engine *gin.Engine) {
 
 	healthController := controllers.HealthController{}
 	oauthClientsController := oauth_controllers.OAuthClientsController{}
+	registerController := controllers.UsersController{}
 
 	v1.GET("/health", healthController.HealthStatus)
 	v1.POST("/oauth/clients", oauthClientsController.Create)
+	v1.POST("/register", registerController.Register)
 }

--- a/lib/api/v1/serializers/error.go
+++ b/lib/api/v1/serializers/error.go
@@ -1,6 +1,6 @@
 package serializers
 
 type ErrorResponse struct {
-	Error       string `json:"error"`
-	ErrorDetail string `json:"detail"`
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description"`
 }

--- a/lib/api/v1/serializers/registration.go
+++ b/lib/api/v1/serializers/registration.go
@@ -1,0 +1,7 @@
+package serializers
+
+type RegistrationResponse struct {
+	UserID       int64  `json:"user_id"`
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+}

--- a/lib/models/user.go
+++ b/lib/models/user.go
@@ -32,8 +32,8 @@ func GetUserByID(id int64) (*User, error) {
 	return user, nil
 }
 
-// UserEmailAlreadyExist retrieves user email and returns true if user with email already exist.
-func UserEmailAlreadyExist(email string) bool {
+// UserEmailAlreadyExisted retrieves user email and returns true if user with email already exist.
+func UserEmailAlreadyExisted(email string) bool {
 	_, err := GetUserByEmail(email)
 
 	return err == nil
@@ -46,4 +46,14 @@ func GetUserByEmail(email string) (*User, error) {
 	result := database.GetDB().Where("email = ?", email).First(&user)
 
 	return user, result.Error
+}
+
+func DeleteUser(userID int64) error {
+	result := database.GetDB().Delete(&User{}, userID)
+
+	if result.Error != nil {
+		return result.Error
+	}
+
+	return nil
 }

--- a/lib/models/user_test.go
+++ b/lib/models/user_test.go
@@ -80,12 +80,12 @@ var _ = Describe("User", func() {
 		})
 	})
 
-	Describe("#UserEmailAlreadyExist", func() {
+	Describe("#UserEmailAlreadyExisted", func() {
 		Context("given user email exist in the system", func() {
 			It("returns true", func() {
 				user := FabricateUser(faker.Email(), faker.Password())
 
-				userExist := models.UserEmailAlreadyExist(user.Email)
+				userExist := models.UserEmailAlreadyExisted(user.Email)
 
 				Expect(userExist).To(BeTrue())
 			})
@@ -93,7 +93,7 @@ var _ = Describe("User", func() {
 
 		Context("given user email does NOT exist in the system", func() {
 			It("returns false", func() {
-				userExist := models.UserEmailAlreadyExist(faker.Email())
+				userExist := models.UserEmailAlreadyExisted(faker.Email())
 
 				Expect(userExist).To(BeFalse())
 			})

--- a/lib/services/oauth/server.go
+++ b/lib/services/oauth/server.go
@@ -10,7 +10,6 @@ import (
 	"go-google-scraper-challenge/helpers/log"
 	"go-google-scraper-challenge/lib/models"
 
-	"github.com/gin-gonic/gin"
 	"github.com/jackc/pgx/v4"
 	pg "github.com/vgarvardt/go-oauth2-pg"
 	"github.com/vgarvardt/go-pg-adapter/pgx4adapter"
@@ -66,10 +65,6 @@ func SetUpOauth() {
 
 	oauthServer = authServer
 	clientStore = store
-}
-
-func ValidateRequest(c *gin.Context) (req *server.AuthorizeRequest, err error) {
-	return oauthServer.ValidationAuthorizeRequest(c.Request)
 }
 
 // GenerateToken handle token request, will return error if fail

--- a/lib/services/oauth/server.go
+++ b/lib/services/oauth/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jackc/pgx/v4"
 	pg "github.com/vgarvardt/go-oauth2-pg"
 	"github.com/vgarvardt/go-pg-adapter/pgx4adapter"
+	"gopkg.in/oauth2.v3"
 	"gopkg.in/oauth2.v3/errors"
 	"gopkg.in/oauth2.v3/manage"
 	"gopkg.in/oauth2.v3/server"

--- a/lib/services/oauth/server.go
+++ b/lib/services/oauth/server.go
@@ -22,6 +22,12 @@ import (
 var oauthServer *server.Server
 var clientStore *pg.ClientStore
 
+type TokenRequest struct {
+	ClientID     string
+	ClientSecret string
+	UserID       string
+}
+
 // SetUpOauth setup OAuth server
 func SetUpOauth() {
 	dbURL := database.GetDatabaseURL()
@@ -54,15 +60,26 @@ func SetUpOauth() {
 	authServer.SetInternalErrorHandler(internalErrorHandler)
 	authServer.SetResponseErrorHandler(responseErrorHandler)
 	authServer.SetPasswordAuthorizationHandler(passwordAuthorizationHandler)
+	authServer.SetAllowedGrantType(oauth2.PasswordCredentials, oauth2.Refreshing)
 	manager.SetRefreshTokenCfg(manage.DefaultRefreshTokenCfg)
 
 	oauthServer = authServer
 	clientStore = store
 }
 
-// GenerateToken handle token request, will return error if request from given context is invalid
-func GenerateToken(c *gin.Context) (err error) {
-	return oauthServer.HandleTokenRequest(c.Writer, c.Request)
+func ValidateRequest(c *gin.Context) (req *server.AuthorizeRequest, err error) {
+	return oauthServer.ValidationAuthorizeRequest(c.Request)
+}
+
+// GenerateToken handle token request, will return error if fail
+func GenerateToken(request *TokenRequest) (tokenInfo oauth2.TokenInfo, err error) {
+	tokenRequest := &oauth2.TokenGenerateRequest{
+		ClientID:     request.ClientID,
+		ClientSecret: request.ClientSecret,
+		UserID:       request.UserID,
+	}
+
+	return oauthServer.GetAccessToken(oauth2.PasswordCredentials, tokenRequest)
 }
 
 // GetClientStore returns OAuth client store
@@ -75,6 +92,7 @@ func internalErrorHandler(err error) (response *errors.Response) {
 
 	response = errors.NewResponse(errors.ErrInvalidClient, errors.StatusCodes[errors.ErrInvalidClient])
 	response.Description = errors.Descriptions[errors.ErrInvalidClient]
+
 	return response
 }
 

--- a/test/auth.go
+++ b/test/auth.go
@@ -1,0 +1,16 @@
+package test
+
+import (
+	"go-google-scraper-challenge/lib/services/oauth"
+
+	"github.com/onsi/ginkgo"
+)
+
+func FabricateAuthClient() oauth.OAuthClient {
+	authClient, err := oauth.GenerateClient()
+	if err != nil {
+		ginkgo.Fail("Fail to fablicate auth client")
+	}
+
+	return authClient
+}


### PR DESCRIPTION
[![workerB](https://img.shields.io/endpoint?url=https%3A%2F%2Fworkerb.linearb.io%2Fv2%2Fbadge%2Fprivate%2FU2FsdGVkX18mjzXKbdPtvlWmWWuRBk6p1L2u3StMAqkefhOyQe1Q2u3A4l%2Fcollaboration.svg)](https://workerb.linearb.io/v2/badge/collaboration-page)
Resolved https://github.com/carryall/go-google-scraper-challenge/issues/82

## What happened 👀

- [x] Migrate constraints from the old project
- [x] Add route for registration API and user controller to handle the API call
- [x] Add registration form with validation, use [this validator](https://github.com/asaskevich/govalidator) to reduce the complexity of error message translation

## Insight 📝

N/A

## Proof Of Work 📹

Then use the ID and secret to call POST `/register` API

![Screen Shot 2565-05-23 at 18 49 02](https://user-images.githubusercontent.com/1772999/169813253-b5bb002d-3ff5-4450-b94b-a777c90f763b.png)

The following are some examples of the fail case

Case | Error preview
--- | ---
The client ID and/or secret is invalid | ![Screen Shot 2565-05-25 at 17 44 39](https://user-images.githubusercontent.com/1772999/170245021-1801567c-3205-4006-af29-909e9a816c8b.png)
User with given email is already exist | ![Screen Shot 2565-05-25 at 17 44 18](https://user-images.githubusercontent.com/1772999/170245057-49536d54-d103-4838-9c42-c012e14967d9.png)
User password is too short | ![Screen Shot 2565-05-25 at 17 44 55](https://user-images.githubusercontent.com/1772999/170245155-11581c20-cf8c-4995-8847-50d6cda76073.png)

