### PR TITLE
[#87] Use JSON API structure on the API response

### DIFF
--- a/constants/error.go
+++ b/constants/error.go
@@ -8,3 +8,9 @@ var Errors = map[int]string{
 	http.StatusUnprocessableEntity: "Unprocessable Entity",
 	http.StatusInternalServerError: "Internal Server Error",
 }
+
+const (
+	ERROR_CODE_MALFORM_REQUEST     = "malformed_request"
+	ERROR_CODE_INVALID_PARAM       = "invalid_param"
+	ERROR_CODE_INVALID_CREDENTIALS = "invalid_credentials"
+)

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/go-playground/universal-translator v0.17.0 // indirect
 	github.com/go-playground/validator/v10 v10.2.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/jsonapi v1.0.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgconn v1.12.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -132,6 +132,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/jsonapi v1.0.0 h1:qIGgO5Smu3yJmSs+QlvhQnrscdZfFhiV6S8ryJAglqU=
+github.com/google/jsonapi v1.0.0/go.mod h1:YYHiRPJT8ARXGER8In9VuLv4qvLfDmA9ULQqptbLE4s=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=

--- a/helpers/api/error.go
+++ b/helpers/api/error.go
@@ -2,16 +2,10 @@ package helpers
 
 import (
 	"go-google-scraper-challenge/constants"
-	"go-google-scraper-challenge/lib/api/v1/serializers"
 
 	"github.com/gin-gonic/gin"
 )
 
-func ResponseWithError(ctx *gin.Context, code int, err error) {
-	errorResponse := serializers.ErrorResponse{
-		Error:            constants.Errors[code],
-		ErrorDescription: err.Error(),
-	}
-
-	ctx.JSON(code, errorResponse)
+func ResponseWithError(ctx *gin.Context, status int, err error, code string) {
+	RenderJSONError(ctx, status, err, constants.Errors[status], code)
 }

--- a/helpers/api/response.go
+++ b/helpers/api/response.go
@@ -38,5 +38,6 @@ func payloadFromError(err error, title string, code string) (errorPayload *jsona
 	errorPayload = &jsonapi.ErrorsPayload{
 		Errors: errorObjs,
 	}
+
 	return
 }

--- a/helpers/api/response.go
+++ b/helpers/api/response.go
@@ -1,0 +1,35 @@
+package helpers
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/google/jsonapi"
+)
+
+func RenderJSON(ctx *gin.Context, status_code int, data interface{}) {
+	payload, err := jsonapi.Marshal(data)
+	if err != nil {
+
+	}
+
+	ctx.JSON(status_code, payload)
+}
+
+func RenderJSONError(ctx *gin.Context, status_code int, err error, title string, code string) {
+	payload := payloadFromError(err, title, code)
+
+	ctx.JSON(status_code, payload)
+}
+
+func payloadFromError(err error, title string, code string) jsonapi.ErrorObject {
+	if len(title) == 0 {
+		title = err.Error()
+	}
+
+	payload := jsonapi.ErrorObject{
+		Title:  title,
+		Detail: err.Error(),
+		Code:   code,
+	}
+
+	return payload
+}

--- a/helpers/api/response.go
+++ b/helpers/api/response.go
@@ -24,7 +24,7 @@ func RenderJSONError(ctx *gin.Context, status_code int, err error, title string,
 	ctx.AbortWithStatusJSON(status_code, payload)
 }
 
-func payloadFromError(err error, title string, code string) *jsonapi.ErrorsPayload {
+func payloadFromError(err error, title string, code string) (errorPayload *jsonapi.ErrorsPayload) {
 	if len(title) == 0 {
 		title = err.Error()
 	}
@@ -35,7 +35,8 @@ func payloadFromError(err error, title string, code string) *jsonapi.ErrorsPaylo
 		Code:   code,
 	}}
 
-	return &jsonapi.ErrorsPayload{
+	errorPayload = &jsonapi.ErrorsPayload{
 		Errors: errorObjs,
 	}
+	return
 }

--- a/helpers/api/response.go
+++ b/helpers/api/response.go
@@ -1,6 +1,10 @@
 package helpers
 
 import (
+	"net/http"
+
+	"go-google-scraper-challenge/constants"
+
 	"github.com/gin-gonic/gin"
 	"github.com/google/jsonapi"
 )
@@ -8,7 +12,7 @@ import (
 func RenderJSON(ctx *gin.Context, status_code int, data interface{}) {
 	payload, err := jsonapi.Marshal(data)
 	if err != nil {
-
+		RenderJSONError(ctx, http.StatusInternalServerError, err, constants.Errors[http.StatusInternalServerError], "")
 	}
 
 	ctx.JSON(status_code, payload)
@@ -17,19 +21,21 @@ func RenderJSON(ctx *gin.Context, status_code int, data interface{}) {
 func RenderJSONError(ctx *gin.Context, status_code int, err error, title string, code string) {
 	payload := payloadFromError(err, title, code)
 
-	ctx.JSON(status_code, payload)
+	ctx.AbortWithStatusJSON(status_code, payload)
 }
 
-func payloadFromError(err error, title string, code string) jsonapi.ErrorObject {
+func payloadFromError(err error, title string, code string) *jsonapi.ErrorsPayload {
 	if len(title) == 0 {
 		title = err.Error()
 	}
 
-	payload := jsonapi.ErrorObject{
+	errorObjs := []*jsonapi.ErrorObject{{
 		Title:  title,
 		Detail: err.Error(),
 		Code:   code,
-	}
+	}}
 
-	return payload
+	return &jsonapi.ErrorsPayload{
+		Errors: errorObjs,
+	}
 }

--- a/helpers/authentication.go
+++ b/helpers/authentication.go
@@ -1,7 +1,9 @@
 package helpers
 
 import (
+	"encoding/json"
 	"go-google-scraper-challenge/helpers/log"
+	"go-google-scraper-challenge/lib/api/v1/serializers"
 
 	"golang.org/x/crypto/bcrypt"
 )
@@ -28,4 +30,16 @@ func CompareHashWithPassword(hashedPassword string, password string) bool {
 	}
 
 	return true
+}
+
+func GetTokenInfo(tokenData map[string]interface{}) (tokenInfo *serializers.AuthenticationToken, err error) {
+	tokenInfo = &serializers.AuthenticationToken{}
+	tokenDataString, err := json.Marshal(tokenData)
+	if err != nil {
+		return
+	}
+
+	err = json.Unmarshal(tokenDataString, tokenInfo)
+
+	return
 }

--- a/lib/api/v1/controllers/authentication.go
+++ b/lib/api/v1/controllers/authentication.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 
 	"go-google-scraper-challenge/constants"
+	. "go-google-scraper-challenge/helpers"
 	. "go-google-scraper-challenge/helpers/api"
-	helpers "go-google-scraper-challenge/helpers/api"
 	"go-google-scraper-challenge/lib/api/v1/forms"
 	"go-google-scraper-challenge/lib/api/v1/serializers"
 	"go-google-scraper-challenge/lib/services/oauth"
@@ -47,13 +47,19 @@ func (c *AuthenticationController) Login(ctx *gin.Context) {
 		return
 	}
 
-	response := &serializers.AuthenticationResponse{
-		ID:           int64(rand.Uint64()),
-		AccessToken:  tokenData["access_token"].(string),
-		RefreshToken: tokenData["refresh_token"].(string),
-		ExpiresIn:    tokenData["expires_in"].(int64),
-		TokenType:    tokenData["token_type"].(string),
+	tokenInfo, err := GetTokenInfo(tokenData)
+	if err != nil {
+		ResponseWithError(ctx, http.StatusUnauthorized, errors.New(constants.OAuthClientInvalid), constants.ERROR_CODE_INVALID_CREDENTIALS)
+		return
 	}
 
-	helpers.RenderJSON(ctx, http.StatusOK, response)
+	response := &serializers.AuthenticationResponse{
+		ID:           int64(rand.Uint64()),
+		AccessToken:  tokenInfo.AccessToken,
+		RefreshToken: tokenInfo.RefreshToken,
+		ExpiresIn:    tokenInfo.ExpiresIn,
+		TokenType:    tokenInfo.TokenType,
+	}
+
+	RenderJSON(ctx, http.StatusOK, response)
 }

--- a/lib/api/v1/controllers/authentication.go
+++ b/lib/api/v1/controllers/authentication.go
@@ -6,7 +6,9 @@ import (
 
 	"go-google-scraper-challenge/constants"
 	. "go-google-scraper-challenge/helpers/api"
+	helpers "go-google-scraper-challenge/helpers/api"
 	"go-google-scraper-challenge/lib/api/v1/forms"
+	"go-google-scraper-challenge/lib/api/v1/serializers"
 	"go-google-scraper-challenge/lib/services/oauth"
 
 	"github.com/gin-gonic/gin"
@@ -38,9 +40,18 @@ func (c *AuthenticationController) Login(ctx *gin.Context) {
 		return
 	}
 
-	err = oauth.HandleTokenRequest(ctx)
+	tokenData, err := oauth.HandleTokenRequest(ctx)
 	if err != nil {
 		ResponseWithError(ctx, http.StatusUnauthorized, errors.New(constants.OAuthClientInvalid), constants.ERROR_CODE_INVALID_CREDENTIALS)
 		return
 	}
+
+	response := &serializers.AuthenticationResponse{
+		AccessToken:  tokenData["access_token"].(string),
+		RefreshToken: tokenData["refresh_token"].(string),
+		ExpiresIn:    tokenData["expires_in"].(int64),
+		TokenType:    tokenData["token_type"].(string),
+	}
+
+	helpers.RenderJSON(ctx, http.StatusOK, response)
 }

--- a/lib/api/v1/controllers/authentication.go
+++ b/lib/api/v1/controllers/authentication.go
@@ -22,25 +22,25 @@ func (c *AuthenticationController) Login(ctx *gin.Context) {
 
 	err := ctx.ShouldBindWith(authenticationForm, binding.Form)
 	if err != nil {
-		ResponseWithError(ctx, http.StatusBadRequest, err)
+		ResponseWithError(ctx, http.StatusBadRequest, err, constants.ERROR_CODE_MALFORM_REQUEST)
 		return
 	}
 
 	_, err = authenticationForm.Validate()
 	if err != nil {
-		ResponseWithError(ctx, http.StatusBadRequest, err)
+		ResponseWithError(ctx, http.StatusBadRequest, err, constants.ERROR_CODE_INVALID_PARAM)
 		return
 	}
 
 	err = authenticationForm.ValidateUser()
 	if err != nil {
-		ResponseWithError(ctx, http.StatusUnauthorized, err)
+		ResponseWithError(ctx, http.StatusUnauthorized, err, constants.ERROR_CODE_INVALID_CREDENTIALS)
 		return
 	}
 
 	err = oauth.HandleTokenRequest(ctx)
 	if err != nil {
-		ResponseWithError(ctx, http.StatusUnauthorized, errors.New(constants.OAuthClientInvalid))
+		ResponseWithError(ctx, http.StatusUnauthorized, errors.New(constants.OAuthClientInvalid), constants.ERROR_CODE_INVALID_CREDENTIALS)
 		return
 	}
 }

--- a/lib/api/v1/controllers/authentication.go
+++ b/lib/api/v1/controllers/authentication.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"errors"
+	"math/rand"
 	"net/http"
 
 	"go-google-scraper-challenge/constants"
@@ -47,6 +48,7 @@ func (c *AuthenticationController) Login(ctx *gin.Context) {
 	}
 
 	response := &serializers.AuthenticationResponse{
+		ID:           int64(rand.Uint64()),
 		AccessToken:  tokenData["access_token"].(string),
 		RefreshToken: tokenData["refresh_token"].(string),
 		ExpiresIn:    tokenData["expires_in"].(int64),

--- a/lib/api/v1/controllers/authentication_test.go
+++ b/lib/api/v1/controllers/authentication_test.go
@@ -11,6 +11,7 @@ import (
 	. "go-google-scraper-challenge/test"
 
 	"github.com/bxcodec/faker/v3"
+	"github.com/google/jsonapi"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -55,11 +56,13 @@ var _ = Describe("AuthenticationController", func() {
 				authenticationController := controllers.AuthenticationController{}
 				authenticationController.Login(ctx)
 
-				jsonResponse := serializers.AuthenticationResponse{}
+				jsonResponse := serializers.AuthenticationJSONResponse{}
 				test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
-				Expect(jsonResponse.AccessToken).NotTo(Equal(""))
-				Expect(jsonResponse.RefreshToken).NotTo(Equal(""))
+				Expect(jsonResponse.Data.Attributes.AccessToken).NotTo(Equal(""))
+				Expect(jsonResponse.Data.Attributes.RefreshToken).NotTo(Equal(""))
+				Expect(jsonResponse.Data.Attributes.ExpiresIn).To(BeNumerically(">", 0))
+				Expect(jsonResponse.Data.Attributes.TokenType).NotTo(Equal(""))
 			})
 		})
 
@@ -81,12 +84,12 @@ var _ = Describe("AuthenticationController", func() {
 					authenticationController := controllers.AuthenticationController{}
 					authenticationController.Login(ctx)
 
-					responseBody := serializers.ErrorResponse{}
-					GetJSONResponseBody(response.Result(), &responseBody)
+					jsonResponse := &jsonapi.ErrorsPayload{}
+					test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
-					Expect(response.Code).To(Equal(http.StatusBadRequest))
-					Expect(responseBody.Error).To(Equal(constants.Errors[http.StatusBadRequest]))
-					Expect(responseBody.ErrorDescription).To(Equal("GrantType: cannot be blank."))
+					Expect(jsonResponse.Errors[0].Title).To(Equal(constants.Errors[http.StatusBadRequest]))
+					Expect(jsonResponse.Errors[0].Code).To(Equal(constants.ERROR_CODE_INVALID_PARAM))
+					Expect(jsonResponse.Errors[0].Detail).To(Equal("GrantType: cannot be blank."))
 				})
 			})
 
@@ -107,12 +110,12 @@ var _ = Describe("AuthenticationController", func() {
 					authenticationController := controllers.AuthenticationController{}
 					authenticationController.Login(ctx)
 
-					responseBody := serializers.ErrorResponse{}
-					GetJSONResponseBody(response.Result(), &responseBody)
+					jsonResponse := &jsonapi.ErrorsPayload{}
+					test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
-					Expect(response.Code).To(Equal(http.StatusBadRequest))
-					Expect(responseBody.Error).To(Equal(constants.Errors[http.StatusBadRequest]))
-					Expect(responseBody.ErrorDescription).To(Equal("ClientID: cannot be blank."))
+					Expect(jsonResponse.Errors[0].Title).To(Equal(constants.Errors[http.StatusBadRequest]))
+					Expect(jsonResponse.Errors[0].Code).To(Equal(constants.ERROR_CODE_INVALID_PARAM))
+					Expect(jsonResponse.Errors[0].Detail).To(Equal("ClientID: cannot be blank."))
 				})
 			})
 
@@ -133,12 +136,12 @@ var _ = Describe("AuthenticationController", func() {
 					authenticationController := controllers.AuthenticationController{}
 					authenticationController.Login(ctx)
 
-					responseBody := serializers.ErrorResponse{}
-					GetJSONResponseBody(response.Result(), &responseBody)
+					jsonResponse := &jsonapi.ErrorsPayload{}
+					test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
-					Expect(response.Code).To(Equal(http.StatusBadRequest))
-					Expect(responseBody.Error).To(Equal(constants.Errors[http.StatusBadRequest]))
-					Expect(responseBody.ErrorDescription).To(Equal("ClientSecret: cannot be blank."))
+					Expect(jsonResponse.Errors[0].Title).To(Equal(constants.Errors[http.StatusBadRequest]))
+					Expect(jsonResponse.Errors[0].Code).To(Equal(constants.ERROR_CODE_INVALID_PARAM))
+					Expect(jsonResponse.Errors[0].Detail).To(Equal("ClientSecret: cannot be blank."))
 				})
 			})
 
@@ -159,12 +162,12 @@ var _ = Describe("AuthenticationController", func() {
 					authenticationController := controllers.AuthenticationController{}
 					authenticationController.Login(ctx)
 
-					responseBody := serializers.ErrorResponse{}
-					GetJSONResponseBody(response.Result(), &responseBody)
+					jsonResponse := &jsonapi.ErrorsPayload{}
+					test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
-					Expect(response.Code).To(Equal(http.StatusBadRequest))
-					Expect(responseBody.Error).To(Equal(constants.Errors[http.StatusBadRequest]))
-					Expect(responseBody.ErrorDescription).To(Equal("Email: cannot be blank."))
+					Expect(jsonResponse.Errors[0].Title).To(Equal(constants.Errors[http.StatusBadRequest]))
+					Expect(jsonResponse.Errors[0].Code).To(Equal(constants.ERROR_CODE_INVALID_PARAM))
+					Expect(jsonResponse.Errors[0].Detail).To(Equal("Email: cannot be blank."))
 				})
 			})
 
@@ -185,12 +188,12 @@ var _ = Describe("AuthenticationController", func() {
 					authenticationController := controllers.AuthenticationController{}
 					authenticationController.Login(ctx)
 
-					responseBody := serializers.ErrorResponse{}
-					GetJSONResponseBody(response.Result(), &responseBody)
+					jsonResponse := &jsonapi.ErrorsPayload{}
+					test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
-					Expect(response.Code).To(Equal(http.StatusBadRequest))
-					Expect(responseBody.Error).To(Equal(constants.Errors[http.StatusBadRequest]))
-					Expect(responseBody.ErrorDescription).To(Equal("Password: cannot be blank."))
+					Expect(jsonResponse.Errors[0].Title).To(Equal(constants.Errors[http.StatusBadRequest]))
+					Expect(jsonResponse.Errors[0].Code).To(Equal(constants.ERROR_CODE_INVALID_PARAM))
+					Expect(jsonResponse.Errors[0].Detail).To(Equal("Password: cannot be blank."))
 				})
 			})
 		})
@@ -214,12 +217,13 @@ var _ = Describe("AuthenticationController", func() {
 					authenticationController := controllers.AuthenticationController{}
 					authenticationController.Login(ctx)
 
-					responseBody := serializers.ErrorResponse{}
+					responseBody := jsonapi.ErrorsPayload{}
 					GetJSONResponseBody(response.Result(), &responseBody)
 
 					Expect(response.Code).To(Equal(http.StatusUnauthorized))
-					Expect(responseBody.Error).To(Equal("invalid_client"))
-					Expect(responseBody.ErrorDescription).To(Equal("Client authentication failed"))
+					Expect(responseBody.Errors[0].Title).To(Equal(constants.Errors[http.StatusUnauthorized]))
+					Expect(responseBody.Errors[0].Code).To(Equal(constants.ERROR_CODE_INVALID_CREDENTIALS))
+					Expect(responseBody.Errors[0].Detail).To(Equal(constants.OAuthClientInvalid))
 				})
 			})
 
@@ -241,12 +245,13 @@ var _ = Describe("AuthenticationController", func() {
 					authenticationController := controllers.AuthenticationController{}
 					authenticationController.Login(ctx)
 
-					responseBody := serializers.ErrorResponse{}
+					responseBody := jsonapi.ErrorsPayload{}
 					GetJSONResponseBody(response.Result(), &responseBody)
 
 					Expect(response.Code).To(Equal(http.StatusUnauthorized))
-					Expect(responseBody.Error).To(Equal("invalid_client"))
-					Expect(responseBody.ErrorDescription).To(Equal("Client authentication failed"))
+					Expect(responseBody.Errors[0].Title).To(Equal(constants.Errors[http.StatusUnauthorized]))
+					Expect(responseBody.Errors[0].Code).To(Equal(constants.ERROR_CODE_INVALID_CREDENTIALS))
+					Expect(responseBody.Errors[0].Detail).To(Equal(constants.OAuthClientInvalid))
 				})
 			})
 
@@ -268,12 +273,13 @@ var _ = Describe("AuthenticationController", func() {
 					authenticationController := controllers.AuthenticationController{}
 					authenticationController.Login(ctx)
 
-					responseBody := serializers.ErrorResponse{}
+					responseBody := jsonapi.ErrorsPayload{}
 					GetJSONResponseBody(response.Result(), &responseBody)
 
 					Expect(response.Code).To(Equal(http.StatusUnauthorized))
-					Expect(responseBody.Error).To(Equal(constants.Errors[http.StatusUnauthorized]))
-					Expect(responseBody.ErrorDescription).To(Equal(constants.UserDoesNotExist))
+					Expect(responseBody.Errors[0].Title).To(Equal(constants.Errors[http.StatusUnauthorized]))
+					Expect(responseBody.Errors[0].Code).To(Equal(constants.ERROR_CODE_INVALID_CREDENTIALS))
+					Expect(responseBody.Errors[0].Detail).To(Equal(constants.UserDoesNotExist))
 				})
 			})
 
@@ -294,12 +300,13 @@ var _ = Describe("AuthenticationController", func() {
 					authenticationController := controllers.AuthenticationController{}
 					authenticationController.Login(ctx)
 
-					responseBody := serializers.ErrorResponse{}
+					responseBody := jsonapi.ErrorsPayload{}
 					GetJSONResponseBody(response.Result(), &responseBody)
 
 					Expect(response.Code).To(Equal(http.StatusUnauthorized))
-					Expect(responseBody.Error).To(Equal("invalid_client"))
-					Expect(responseBody.ErrorDescription).To(Equal("Client authentication failed"))
+					Expect(responseBody.Errors[0].Title).To(Equal(constants.Errors[http.StatusUnauthorized]))
+					Expect(responseBody.Errors[0].Code).To(Equal(constants.ERROR_CODE_INVALID_CREDENTIALS))
+					Expect(responseBody.Errors[0].Detail).To(Equal(constants.OAuthClientInvalid))
 				})
 			})
 
@@ -321,12 +328,13 @@ var _ = Describe("AuthenticationController", func() {
 					authenticationController := controllers.AuthenticationController{}
 					authenticationController.Login(ctx)
 
-					responseBody := serializers.ErrorResponse{}
+					responseBody := jsonapi.ErrorsPayload{}
 					GetJSONResponseBody(response.Result(), &responseBody)
 
 					Expect(response.Code).To(Equal(http.StatusUnauthorized))
-					Expect(responseBody.Error).To(Equal("unsupported_grant_type"))
-					Expect(responseBody.ErrorDescription).To(Equal("The authorization grant type is not supported by the authorization server"))
+					Expect(responseBody.Errors[0].Title).To(Equal(constants.Errors[http.StatusUnauthorized]))
+					Expect(responseBody.Errors[0].Code).To(Equal(constants.ERROR_CODE_INVALID_CREDENTIALS))
+					Expect(responseBody.Errors[0].Detail).To(Equal(constants.OAuthClientInvalid))
 				})
 			})
 		})

--- a/lib/api/v1/controllers/authentication_test.go
+++ b/lib/api/v1/controllers/authentication_test.go
@@ -59,6 +59,7 @@ var _ = Describe("AuthenticationController", func() {
 				jsonResponse := serializers.AuthenticationJSONResponse{}
 				test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
+				Expect(jsonResponse.Data.ID).To(BeNumerically(">", 0))
 				Expect(jsonResponse.Data.Attributes.AccessToken).NotTo(Equal(""))
 				Expect(jsonResponse.Data.Attributes.RefreshToken).NotTo(Equal(""))
 				Expect(jsonResponse.Data.Attributes.ExpiresIn).To(BeNumerically(">", 0))

--- a/lib/api/v1/controllers/authentication_test.go
+++ b/lib/api/v1/controllers/authentication_test.go
@@ -59,7 +59,7 @@ var _ = Describe("AuthenticationController", func() {
 				jsonResponse := serializers.AuthenticationJSONResponse{}
 				test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
-				Expect(jsonResponse.Data.ID).To(BeNumerically(">", 0))
+				Expect(jsonResponse.Data.ID).NotTo(Equal(""))
 				Expect(jsonResponse.Data.Attributes.AccessToken).NotTo(Equal(""))
 				Expect(jsonResponse.Data.Attributes.RefreshToken).NotTo(Equal(""))
 				Expect(jsonResponse.Data.Attributes.ExpiresIn).To(BeNumerically(">", 0))

--- a/lib/api/v1/controllers/oauth/clients.go
+++ b/lib/api/v1/controllers/oauth/clients.go
@@ -24,6 +24,7 @@ func (c *OAuthClientsController) Create(ctx *gin.Context) {
 	}
 
 	response := &serializers.OAuthClientResponse{
+		ID:           oauthClient.ClientID,
 		ClientID:     oauthClient.ClientID,
 		ClientSecret: oauthClient.ClientSecret,
 	}

--- a/lib/api/v1/controllers/oauth/clients.go
+++ b/lib/api/v1/controllers/oauth/clients.go
@@ -4,7 +4,9 @@ import (
 	"net/http"
 
 	. "go-google-scraper-challenge/helpers/api"
+	helpers "go-google-scraper-challenge/helpers/api"
 	"go-google-scraper-challenge/lib/api/v1/controllers"
+	"go-google-scraper-challenge/lib/api/v1/serializers"
 	"go-google-scraper-challenge/lib/services/oauth"
 
 	"github.com/gin-gonic/gin"
@@ -21,5 +23,10 @@ func (c *OAuthClientsController) Create(ctx *gin.Context) {
 		ResponseWithError(ctx, http.StatusUnprocessableEntity, err, "")
 	}
 
-	ctx.JSON(http.StatusOK, oauthClient)
+	response := &serializers.OAuthClientResponse{
+		ClientID:     oauthClient.ClientID,
+		ClientSecret: oauthClient.ClientSecret,
+	}
+
+	helpers.RenderJSON(ctx, http.StatusOK, response)
 }

--- a/lib/api/v1/controllers/oauth/clients.go
+++ b/lib/api/v1/controllers/oauth/clients.go
@@ -18,7 +18,7 @@ func (c *OAuthClientsController) Create(ctx *gin.Context) {
 	oauthClient, err := oauth.GenerateClient()
 
 	if err != nil {
-		ResponseWithError(ctx, http.StatusUnprocessableEntity, err)
+		ResponseWithError(ctx, http.StatusUnprocessableEntity, err, "")
 	}
 
 	ctx.JSON(http.StatusOK, oauthClient)

--- a/lib/api/v1/controllers/oauth/clients_test.go
+++ b/lib/api/v1/controllers/oauth/clients_test.go
@@ -35,6 +35,7 @@ var _ = Describe("OAuthClientsController", func() {
 			jsonResponse := serializers.OAuthClientJSONResponse{}
 			test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
+			Expect(jsonResponse.Data.ID).NotTo(BeEmpty())
 			Expect(jsonResponse.Data.Attributes.ClientID).NotTo(BeEmpty())
 			Expect(jsonResponse.Data.Attributes.ClientSecret).NotTo(BeEmpty())
 		})

--- a/lib/api/v1/controllers/oauth/clients_test.go
+++ b/lib/api/v1/controllers/oauth/clients_test.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	controllers "go-google-scraper-challenge/lib/api/v1/controllers/oauth"
-	"go-google-scraper-challenge/lib/services/oauth"
+	"go-google-scraper-challenge/lib/api/v1/serializers"
 	"go-google-scraper-challenge/test"
 	. "go-google-scraper-challenge/test"
 
@@ -20,7 +20,7 @@ var _ = Describe("OAuthClientsController", func() {
 			oauthClientsController := controllers.OAuthClientsController{}
 			oauthClientsController.Create(ctx)
 
-			jsonResponse := oauth.OAuthClient{}
+			jsonResponse := serializers.OAuthClientJSONResponse{}
 			test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
 			Expect(response.Code).To(Equal(http.StatusOK))
@@ -32,11 +32,11 @@ var _ = Describe("OAuthClientsController", func() {
 			oauthClientsController := controllers.OAuthClientsController{}
 			oauthClientsController.Create(ctx)
 
-			jsonResponse := oauth.OAuthClient{}
+			jsonResponse := serializers.OAuthClientJSONResponse{}
 			test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
-			Expect(jsonResponse.ClientID).NotTo(BeEmpty())
-			Expect(jsonResponse.ClientSecret).NotTo(BeEmpty())
+			Expect(jsonResponse.Data.Attributes.ClientID).NotTo(BeEmpty())
+			Expect(jsonResponse.Data.Attributes.ClientSecret).NotTo(BeEmpty())
 		})
 	})
 

--- a/lib/api/v1/controllers/users.go
+++ b/lib/api/v1/controllers/users.go
@@ -7,6 +7,7 @@ import (
 
 	"go-google-scraper-challenge/constants"
 	. "go-google-scraper-challenge/helpers/api"
+	helpers "go-google-scraper-challenge/helpers/api"
 	"go-google-scraper-challenge/lib/api/v1/forms"
 	"go-google-scraper-challenge/lib/api/v1/serializers"
 	"go-google-scraper-challenge/lib/models"
@@ -60,5 +61,5 @@ func (c *UsersController) Register(ctx *gin.Context) {
 		RefreshToken: tokenInfo.GetRefresh(),
 	}
 
-	ctx.JSON(http.StatusOK, response)
+	helpers.RenderJSON(ctx, http.StatusOK, response)
 }

--- a/lib/api/v1/controllers/users.go
+++ b/lib/api/v1/controllers/users.go
@@ -26,19 +26,19 @@ func (c *UsersController) Register(ctx *gin.Context) {
 
 	err := ctx.ShouldBindWith(registrationForm, binding.Form)
 	if err != nil {
-		ResponseWithError(ctx, http.StatusBadRequest, err)
+		ResponseWithError(ctx, http.StatusBadRequest, err, constants.ERROR_CODE_MALFORM_REQUEST)
 		return
 	}
 
 	_, err = registrationForm.Validate()
 	if err != nil {
-		ResponseWithError(ctx, http.StatusBadRequest, err)
+		ResponseWithError(ctx, http.StatusBadRequest, err, constants.ERROR_CODE_INVALID_PARAM)
 		return
 	}
 
 	userID, err := registrationForm.Save()
 	if err != nil {
-		ResponseWithError(ctx, http.StatusUnprocessableEntity, err)
+		ResponseWithError(ctx, http.StatusUnprocessableEntity, err, constants.ERROR_CODE_INVALID_PARAM)
 		return
 	}
 
@@ -51,11 +51,11 @@ func (c *UsersController) Register(ctx *gin.Context) {
 	tokenInfo, err := oauth.GenerateToken(tokenRequest)
 	if err != nil {
 		_ = models.DeleteUser(userID)
-		ResponseWithError(ctx, http.StatusUnauthorized, errors.New(constants.OAuthClientInvalid))
+		ResponseWithError(ctx, http.StatusUnauthorized, errors.New(constants.OAuthClientInvalid), constants.ERROR_CODE_INVALID_CREDENTIALS)
 		return
 	}
 
-	response := serializers.RegistrationResponse{
+	response := &serializers.RegistrationResponse{
 		UserID:       userID,
 		AccessToken:  tokenInfo.GetAccess(),
 		RefreshToken: tokenInfo.GetRefresh(),

--- a/lib/api/v1/controllers/users.go
+++ b/lib/api/v1/controllers/users.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"errors"
 	"fmt"
+	"math/rand"
 	"net/http"
 
 	"go-google-scraper-challenge/constants"
@@ -56,6 +57,7 @@ func (c *UsersController) Register(ctx *gin.Context) {
 	}
 
 	response := &serializers.RegistrationResponse{
+		ID:           int64(rand.Uint64()),
 		UserID:       userID,
 		AccessToken:  tokenInfo.GetAccess(),
 		RefreshToken: tokenInfo.GetRefresh(),

--- a/lib/api/v1/controllers/users_test.go
+++ b/lib/api/v1/controllers/users_test.go
@@ -53,6 +53,7 @@ var _ = Describe("UsersController", func() {
 				jsonResponse := serializers.RegistrationJSONResponse{}
 				test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
+				Expect(jsonResponse.Data.ID).To(BeNumerically(">", 0))
 				Expect(jsonResponse.Data.Attributes.UserID).To(BeNumerically(">", 0))
 				Expect(jsonResponse.Data.Attributes.AccessToken).NotTo(Equal(""))
 				Expect(jsonResponse.Data.Attributes.RefreshToken).NotTo(Equal(""))

--- a/lib/api/v1/controllers/users_test.go
+++ b/lib/api/v1/controllers/users_test.go
@@ -11,6 +11,7 @@ import (
 	. "go-google-scraper-challenge/test"
 
 	"github.com/bxcodec/faker/v3"
+	"github.com/google/jsonapi"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -49,12 +50,12 @@ var _ = Describe("UsersController", func() {
 				usersController := controllers.UsersController{}
 				usersController.Register(ctx)
 
-				jsonResponse := serializers.RegistrationResponse{}
+				jsonResponse := serializers.RegistrationJSONResponse{}
 				test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
-				Expect(jsonResponse.UserID).To(BeNumerically(">", 0))
-				Expect(jsonResponse.AccessToken).NotTo(Equal(""))
-				Expect(jsonResponse.RefreshToken).NotTo(Equal(""))
+				Expect(jsonResponse.Data.Attributes.UserID).To(BeNumerically(">", 0))
+				Expect(jsonResponse.Data.Attributes.AccessToken).NotTo(Equal(""))
+				Expect(jsonResponse.Data.Attributes.RefreshToken).NotTo(Equal(""))
 			})
 		})
 
@@ -92,11 +93,12 @@ var _ = Describe("UsersController", func() {
 						usersController := controllers.UsersController{}
 						usersController.Register(ctx)
 
-						jsonResponse := serializers.ErrorResponse{}
+						jsonResponse := &jsonapi.ErrorsPayload{}
 						test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
-						Expect(jsonResponse.Error).To(Equal(constants.Errors[http.StatusBadRequest]))
-						Expect(jsonResponse.ErrorDescription).To(Equal("ClientID: cannot be blank."))
+						Expect(jsonResponse.Errors[0].Title).To(Equal(constants.Errors[http.StatusBadRequest]))
+						Expect(jsonResponse.Errors[0].Code).To(Equal(constants.ERROR_CODE_INVALID_PARAM))
+						Expect(jsonResponse.Errors[0].Detail).To(Equal("ClientID: cannot be blank."))
 					})
 				})
 
@@ -132,11 +134,12 @@ var _ = Describe("UsersController", func() {
 						usersController := controllers.UsersController{}
 						usersController.Register(ctx)
 
-						jsonResponse := serializers.ErrorResponse{}
+						jsonResponse := &jsonapi.ErrorsPayload{}
 						test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
-						Expect(jsonResponse.Error).To(Equal(constants.Errors[http.StatusUnauthorized]))
-						Expect(jsonResponse.ErrorDescription).To(Equal(constants.OAuthClientInvalid))
+						Expect(jsonResponse.Errors[0].Title).To(Equal(constants.Errors[http.StatusUnauthorized]))
+						Expect(jsonResponse.Errors[0].Code).To(Equal(constants.ERROR_CODE_INVALID_CREDENTIALS))
+						Expect(jsonResponse.Errors[0].Detail).To(Equal(constants.OAuthClientInvalid))
 					})
 				})
 			})
@@ -174,11 +177,12 @@ var _ = Describe("UsersController", func() {
 						usersController := controllers.UsersController{}
 						usersController.Register(ctx)
 
-						jsonResponse := serializers.ErrorResponse{}
+						jsonResponse := &jsonapi.ErrorsPayload{}
 						test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
-						Expect(jsonResponse.Error).To(Equal(constants.Errors[http.StatusBadRequest]))
-						Expect(jsonResponse.ErrorDescription).To(Equal("ClientSecret: cannot be blank."))
+						Expect(jsonResponse.Errors[0].Title).To(Equal(constants.Errors[http.StatusBadRequest]))
+						Expect(jsonResponse.Errors[0].Code).To(Equal(constants.ERROR_CODE_INVALID_PARAM))
+						Expect(jsonResponse.Errors[0].Detail).To(Equal("ClientSecret: cannot be blank."))
 					})
 				})
 
@@ -214,11 +218,12 @@ var _ = Describe("UsersController", func() {
 						usersController := controllers.UsersController{}
 						usersController.Register(ctx)
 
-						jsonResponse := serializers.ErrorResponse{}
+						jsonResponse := &jsonapi.ErrorsPayload{}
 						test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
-						Expect(jsonResponse.Error).To(Equal(constants.Errors[http.StatusUnauthorized]))
-						Expect(jsonResponse.ErrorDescription).To(Equal(constants.OAuthClientInvalid))
+						Expect(jsonResponse.Errors[0].Title).To(Equal(constants.Errors[http.StatusUnauthorized]))
+						Expect(jsonResponse.Errors[0].Code).To(Equal(constants.ERROR_CODE_INVALID_CREDENTIALS))
+						Expect(jsonResponse.Errors[0].Detail).To(Equal(constants.OAuthClientInvalid))
 					})
 				})
 			})
@@ -256,11 +261,12 @@ var _ = Describe("UsersController", func() {
 						usersController := controllers.UsersController{}
 						usersController.Register(ctx)
 
-						jsonResponse := serializers.ErrorResponse{}
+						jsonResponse := &jsonapi.ErrorsPayload{}
 						test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
-						Expect(jsonResponse.Error).To(Equal(constants.Errors[http.StatusBadRequest]))
-						Expect(jsonResponse.ErrorDescription).To(Equal("Email: cannot be blank."))
+						Expect(jsonResponse.Errors[0].Title).To(Equal(constants.Errors[http.StatusBadRequest]))
+						Expect(jsonResponse.Errors[0].Code).To(Equal(constants.ERROR_CODE_INVALID_PARAM))
+						Expect(jsonResponse.Errors[0].Detail).To(Equal("Email: cannot be blank."))
 					})
 				})
 
@@ -296,11 +302,12 @@ var _ = Describe("UsersController", func() {
 						usersController := controllers.UsersController{}
 						usersController.Register(ctx)
 
-						jsonResponse := serializers.ErrorResponse{}
+						jsonResponse := &jsonapi.ErrorsPayload{}
 						test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
-						Expect(jsonResponse.Error).To(Equal(constants.Errors[http.StatusBadRequest]))
-						Expect(jsonResponse.ErrorDescription).To(Equal("Email: must be a valid email address."))
+						Expect(jsonResponse.Errors[0].Title).To(Equal(constants.Errors[http.StatusBadRequest]))
+						Expect(jsonResponse.Errors[0].Code).To(Equal(constants.ERROR_CODE_INVALID_PARAM))
+						Expect(jsonResponse.Errors[0].Detail).To(Equal("Email: must be a valid email address."))
 					})
 				})
 			})
@@ -338,11 +345,12 @@ var _ = Describe("UsersController", func() {
 						usersController := controllers.UsersController{}
 						usersController.Register(ctx)
 
-						jsonResponse := serializers.ErrorResponse{}
+						jsonResponse := &jsonapi.ErrorsPayload{}
 						test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
-						Expect(jsonResponse.Error).To(Equal(constants.Errors[http.StatusBadRequest]))
-						Expect(jsonResponse.ErrorDescription).To(Equal("Password: cannot be blank."))
+						Expect(jsonResponse.Errors[0].Title).To(Equal(constants.Errors[http.StatusBadRequest]))
+						Expect(jsonResponse.Errors[0].Code).To(Equal(constants.ERROR_CODE_INVALID_PARAM))
+						Expect(jsonResponse.Errors[0].Detail).To(Equal("Password: cannot be blank."))
 					})
 				})
 
@@ -378,11 +386,12 @@ var _ = Describe("UsersController", func() {
 						usersController := controllers.UsersController{}
 						usersController.Register(ctx)
 
-						jsonResponse := serializers.ErrorResponse{}
+						jsonResponse := &jsonapi.ErrorsPayload{}
 						test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
-						Expect(jsonResponse.Error).To(Equal(constants.Errors[http.StatusBadRequest]))
-						Expect(jsonResponse.ErrorDescription).To(Equal("Password: the length must be between 6 and 50."))
+						Expect(jsonResponse.Errors[0].Title).To(Equal(constants.Errors[http.StatusBadRequest]))
+						Expect(jsonResponse.Errors[0].Code).To(Equal(constants.ERROR_CODE_INVALID_PARAM))
+						Expect(jsonResponse.Errors[0].Detail).To(Equal("Password: the length must be between 6 and 50."))
 					})
 				})
 			})

--- a/lib/api/v1/controllers/users_test.go
+++ b/lib/api/v1/controllers/users_test.go
@@ -53,7 +53,7 @@ var _ = Describe("UsersController", func() {
 				jsonResponse := serializers.RegistrationJSONResponse{}
 				test.GetJSONResponseBody(response.Result(), &jsonResponse)
 
-				Expect(jsonResponse.Data.ID).To(BeNumerically(">", 0))
+				Expect(jsonResponse.Data.ID).NotTo(Equal(""))
 				Expect(jsonResponse.Data.Attributes.UserID).To(BeNumerically(">", 0))
 				Expect(jsonResponse.Data.Attributes.AccessToken).NotTo(Equal(""))
 				Expect(jsonResponse.Data.Attributes.RefreshToken).NotTo(Equal(""))

--- a/lib/api/v1/serializers/authentication.go
+++ b/lib/api/v1/serializers/authentication.go
@@ -1,7 +1,7 @@
 package serializers
 
 type AuthenticationResponse struct {
-	ID           string `jsonapi:"primary,authentications"`
+	ID           int64  `jsonapi:"primary,authentications"`
 	AccessToken  string `jsonapi:"attr,access_token"`
 	RefreshToken string `jsonapi:"attr,refresh_token"`
 	ExpiresIn    int64  `jsonapi:"attr,expires_in"`
@@ -10,7 +10,7 @@ type AuthenticationResponse struct {
 
 type AuthenticationJSONResponse struct {
 	Data struct {
-		ID         string `json:"id"`
+		ID         int64 `json:"id"`
 		Attributes struct {
 			UserID       int64  `json:"user_id"`
 			AccessToken  string `json:"access_token"`

--- a/lib/api/v1/serializers/authentication.go
+++ b/lib/api/v1/serializers/authentication.go
@@ -1,7 +1,22 @@
 package serializers
 
 type AuthenticationResponse struct {
-	ID           string `jsonapi:"primary,authentication"`
+	ID           string `jsonapi:"primary,authentications"`
 	AccessToken  string `jsonapi:"attr,access_token"`
 	RefreshToken string `jsonapi:"attr,refresh_token"`
+	ExpiresIn    int64  `jsonapi:"attr,expires_in"`
+	TokenType    string `jsonapi:"attr,token_type"`
+}
+
+type AuthenticationJSONResponse struct {
+	Data struct {
+		ID         string `json:"id"`
+		Attributes struct {
+			UserID       int64  `json:"user_id"`
+			AccessToken  string `json:"access_token"`
+			RefreshToken string `json:"refresh_token"`
+			ExpiresIn    int64  `json:"expires_in"`
+			TokenType    string `json:"token_type"`
+		} `json:"attributes"`
+	} `json:"data"`
 }

--- a/lib/api/v1/serializers/authentication.go
+++ b/lib/api/v1/serializers/authentication.go
@@ -10,7 +10,7 @@ type AuthenticationResponse struct {
 
 type AuthenticationJSONResponse struct {
 	Data struct {
-		ID         int64 `json:"id"`
+		ID         string `json:"id"`
 		Attributes struct {
 			UserID       int64  `json:"user_id"`
 			AccessToken  string `json:"access_token"`

--- a/lib/api/v1/serializers/authentication.go
+++ b/lib/api/v1/serializers/authentication.go
@@ -20,3 +20,10 @@ type AuthenticationJSONResponse struct {
 		} `json:"attributes"`
 	} `json:"data"`
 }
+
+type AuthenticationToken struct {
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+	ExpiresIn    int64  `json:"expires_in"`
+	TokenType    string `json:"token_type"`
+}

--- a/lib/api/v1/serializers/authentication.go
+++ b/lib/api/v1/serializers/authentication.go
@@ -1,6 +1,7 @@
 package serializers
 
 type AuthenticationResponse struct {
-	AccessToken  string `json:"access_token"`
-	RefreshToken string `json:"refresh_token"`
+	ID           string `jsonapi:"primary,authentication"`
+	AccessToken  string `jsonapi:"attr,access_token"`
+	RefreshToken string `jsonapi:"attr,refresh_token"`
 }

--- a/lib/api/v1/serializers/error.go
+++ b/lib/api/v1/serializers/error.go
@@ -1,6 +1,0 @@
-package serializers
-
-type ErrorResponse struct {
-	Error            string `json:"error"`
-	ErrorDescription string `json:"error_description"`
-}

--- a/lib/api/v1/serializers/oauth_client.go
+++ b/lib/api/v1/serializers/oauth_client.go
@@ -1,0 +1,17 @@
+package serializers
+
+type OAuthClientResponse struct {
+	ID           string `jsonapi:"primary,oauth_clients"`
+	ClientID     string `jsonapi:"attr,client_id"`
+	ClientSecret string `jsonapi:"attr,client_secret"`
+}
+
+type OAuthClientJSONResponse struct {
+	Data struct {
+		ID         string `json:"id"`
+		Attributes struct {
+			ClientID     string `json:"client_id"`
+			ClientSecret string `json:"client_secret"`
+		} `json:"attributes"`
+	} `json:"data"`
+}

--- a/lib/api/v1/serializers/registration.go
+++ b/lib/api/v1/serializers/registration.go
@@ -1,7 +1,7 @@
 package serializers
 
 type RegistrationResponse struct {
-	ID           string `jsonapi:"primary,registrations"`
+	ID           int64  `jsonapi:"primary,registrations"`
 	UserID       int64  `jsonapi:"attr,user_id"`
 	AccessToken  string `jsonapi:"attr,access_token"`
 	RefreshToken string `jsonapi:"attr,refresh_token"`
@@ -9,7 +9,7 @@ type RegistrationResponse struct {
 
 type RegistrationJSONResponse struct {
 	Data struct {
-		ID         string `json:"id"`
+		ID         int64 `json:"id"`
 		Attributes struct {
 			UserID       int64  `json:"user_id"`
 			AccessToken  string `json:"access_token"`

--- a/lib/api/v1/serializers/registration.go
+++ b/lib/api/v1/serializers/registration.go
@@ -1,7 +1,8 @@
 package serializers
 
 type RegistrationResponse struct {
-	UserID       int64  `json:"user_id"`
-	AccessToken  string `json:"access_token"`
-	RefreshToken string `json:"refresh_token"`
+	ID           string `jsonapi:"primary,registration"`
+	UserID       int64  `jsonapi:"attr,user_id"`
+	AccessToken  string `jsonapi:"attr,access_token"`
+	RefreshToken string `jsonapi:"attr,refresh_token"`
 }

--- a/lib/api/v1/serializers/registration.go
+++ b/lib/api/v1/serializers/registration.go
@@ -9,7 +9,7 @@ type RegistrationResponse struct {
 
 type RegistrationJSONResponse struct {
 	Data struct {
-		ID         int64 `json:"id"`
+		ID         string `json:"id"`
 		Attributes struct {
 			UserID       int64  `json:"user_id"`
 			AccessToken  string `json:"access_token"`

--- a/lib/api/v1/serializers/registration.go
+++ b/lib/api/v1/serializers/registration.go
@@ -1,8 +1,19 @@
 package serializers
 
 type RegistrationResponse struct {
-	ID           string `jsonapi:"primary,registration"`
+	ID           string `jsonapi:"primary,registrations"`
 	UserID       int64  `jsonapi:"attr,user_id"`
 	AccessToken  string `jsonapi:"attr,access_token"`
 	RefreshToken string `jsonapi:"attr,refresh_token"`
+}
+
+type RegistrationJSONResponse struct {
+	Data struct {
+		ID         string `json:"id"`
+		Attributes struct {
+			UserID       int64  `json:"user_id"`
+			AccessToken  string `json:"access_token"`
+			RefreshToken string `json:"refresh_token"`
+		} `json:"attributes"`
+	} `json:"data"`
 }

--- a/lib/services/oauth/server.go
+++ b/lib/services/oauth/server.go
@@ -68,8 +68,19 @@ func SetUpOauth() {
 	clientStore = store
 }
 
-func HandleTokenRequest(ctx *gin.Context) (err error) {
-	return oauthServer.HandleTokenRequest(ctx.Writer, ctx.Request)
+func HandleTokenRequest(ctx *gin.Context) (token_data map[string]interface{}, err error) {
+	gt, tgr, err := oauthServer.ValidationTokenRequest(ctx.Request)
+	if err != nil {
+		return
+	}
+
+	ti, err := oauthServer.GetAccessToken(gt, tgr)
+	if err != nil {
+		return
+	}
+
+	token_data = oauthServer.GetTokenData(ti)
+	return
 }
 
 // GenerateToken handle token request, will return error if fail

--- a/test/controller.go
+++ b/test/controller.go
@@ -1,14 +1,13 @@
 package test
 
 import (
-	"encoding/json"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/jsonapi"
 	"github.com/onsi/ginkgo"
 )
 
@@ -50,21 +49,9 @@ func HTTPRequest(method string, url string, body io.Reader) *http.Request {
 	return request
 }
 
-// GetResponseBody get response body from response, will fail the test if there is any error
-func GetResponseBody(response *http.Response) string {
-	body, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		ginkgo.Fail("Failed to read response body")
-	}
-
-	return string(body)
-}
-
 // GetJSONResponseBody get response body from response, will fail the test if there is any error
 func GetJSONResponseBody(response *http.Response, v interface{}) {
-	body := GetResponseBody(response)
-
-	err := json.Unmarshal([]byte(body), v)
+	err := jsonapi.UnmarshalPayload(response.Body, v)
 	if err != nil {
 		ginkgo.Fail("Failed to unmarshal json response " + err.Error())
 	}

--- a/test/controller.go
+++ b/test/controller.go
@@ -1,13 +1,14 @@
 package test
 
 import (
+	"encoding/json"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 
 	"github.com/gin-gonic/gin"
-	"github.com/google/jsonapi"
 	"github.com/onsi/ginkgo"
 )
 
@@ -51,8 +52,20 @@ func HTTPRequest(method string, url string, body io.Reader) *http.Request {
 
 // GetJSONResponseBody get response body from response, will fail the test if there is any error
 func GetJSONResponseBody(response *http.Response, v interface{}) {
-	err := jsonapi.UnmarshalPayload(response.Body, v)
+	body := responseBody(response)
+
+	err := json.Unmarshal([]byte(body), v)
+
 	if err != nil {
 		ginkgo.Fail("Failed to unmarshal json response " + err.Error())
 	}
+}
+
+func responseBody(response *http.Response) string {
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		ginkgo.Fail("Failed to read response body")
+	}
+
+	return string(body)
 }


### PR DESCRIPTION
Resolves https://github.com/carryall/go-google-scraper-challenge/issues/87

## What happened 👀

- Add [JSON API](https://github.com/google/jsonapi) and update serializer to follow its format
- Add helper functions to handle JSON responses for the API controllers
- Add the error code for error responses
- Update the OAuth server to handle token requests manually so that we can populate the response on our own using the token data
- Update tests

## Insight 📝

N/A

## Proof Of Work 📹

The response is in the expected format

API endpoints | Preview
--- | ---
OAuth Client API | ![Screen Shot 2565-05-31 at 17 29 23](https://user-images.githubusercontent.com/1772999/171155034-0e3fbf2f-bd74-480a-ae72-f7306e38c3e7.png)
Register API | ![Screen Shot 2565-05-31 at 17 35 17](https://user-images.githubusercontent.com/1772999/171155145-b62b70ce-270b-4e81-8909-10172f94c2f5.png)
Login API | ![Screen Shot 2565-05-31 at 17 37 21](https://user-images.githubusercontent.com/1772999/171155176-8150478a-7817-47d2-8a88-675cd8289658.png)

Also, the error responses are all in the same format with an error code

API endpoints | Preview
--- | ---
Register API | ![Screen Shot 2565-05-31 at 17 34 55](https://user-images.githubusercontent.com/1772999/171155384-60e12cc4-ff35-43d6-8d7a-d6ce6577041b.png)
Login API | ![Screen Shot 2565-05-31 at 17 37 33](https://user-images.githubusercontent.com/1772999/171155443-11dec672-6c3f-4e7b-a0d7-117f055fa34b.png)
 