### PR TITLE
[#8] [API] As a user, I can see a list of the report regarding the keywords from files I uploaded

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,4 +1,4 @@
-package helpers
+package config
 
 import (
 	"github.com/gin-gonic/gin"

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,7 +1,7 @@
-package helpers_test
+package config_test
 
 import (
-	"go-google-scraper-challenge/helpers"
+	"go-google-scraper-challenge/config"
 
 	"github.com/gin-gonic/gin"
 	. "github.com/onsi/ginkgo"
@@ -16,7 +16,7 @@ var _ = Describe("Config", func() {
 				gin.SetMode(gin.ReleaseMode)
 				defer gin.SetMode(gin.TestMode)
 
-				result := helpers.GetConfigPrefix()
+				result := config.GetConfigPrefix()
 
 				Expect(result).To(BeEmpty())
 			})
@@ -27,7 +27,7 @@ var _ = Describe("Config", func() {
 				gin.SetMode(gin.DebugMode)
 				defer gin.SetMode(gin.TestMode)
 
-				result := helpers.GetConfigPrefix()
+				result := config.GetConfigPrefix()
 
 				Expect(result).To(Equal("debug."))
 			})
@@ -38,7 +38,7 @@ var _ = Describe("Config", func() {
 				gin.SetMode(gin.TestMode)
 				defer gin.SetMode(gin.TestMode)
 
-				result := helpers.GetConfigPrefix()
+				result := config.GetConfigPrefix()
 
 				Expect(result).To(Equal("test."))
 			})
@@ -50,7 +50,7 @@ var _ = Describe("Config", func() {
 			It("returns true", func() {
 				viper.Set("test.bool_config", true)
 
-				result := helpers.GetBoolConfig("bool_config")
+				result := config.GetBoolConfig("bool_config")
 
 				Expect(result).To(BeTrue())
 			})
@@ -60,7 +60,7 @@ var _ = Describe("Config", func() {
 			It("returns false", func() {
 				viper.Set("test.bool_config", true)
 
-				result := helpers.GetBoolConfig("invalid")
+				result := config.GetBoolConfig("invalid")
 
 				Expect(result).To(BeFalse())
 			})
@@ -72,7 +72,7 @@ var _ = Describe("Config", func() {
 			It("returns correct config value", func() {
 				viper.Set("test.float_config", 1.0)
 
-				result := helpers.GetFloatConfig("float_config")
+				result := config.GetFloatConfig("float_config")
 
 				Expect(result).To(Equal(1.0))
 			})
@@ -82,7 +82,7 @@ var _ = Describe("Config", func() {
 			It("returns zero", func() {
 				viper.Set("test.float_config", 1.0)
 
-				result := helpers.GetFloatConfig("invalid")
+				result := config.GetFloatConfig("invalid")
 
 				Expect(result).To(BeZero())
 			})
@@ -94,7 +94,7 @@ var _ = Describe("Config", func() {
 			It("returns correct config value", func() {
 				viper.Set("test.int_config", 1)
 
-				result := helpers.GetIntConfig("int_config")
+				result := config.GetIntConfig("int_config")
 
 				Expect(result).To(Equal(1))
 			})
@@ -104,7 +104,7 @@ var _ = Describe("Config", func() {
 			It("returns zero", func() {
 				viper.Set("test.int_config", 1)
 
-				result := helpers.GetIntConfig("invalid")
+				result := config.GetIntConfig("invalid")
 
 				Expect(result).To(BeZero())
 			})
@@ -116,7 +116,7 @@ var _ = Describe("Config", func() {
 			It("returns correct config value", func() {
 				viper.Set("test.string_config", "some string")
 
-				result := helpers.GetStringConfig("string_config")
+				result := config.GetStringConfig("string_config")
 
 				Expect(result).To(Equal("some string"))
 			})
@@ -126,7 +126,7 @@ var _ = Describe("Config", func() {
 			It("returns empty config value", func() {
 				viper.Set("test.string_config", "some string")
 
-				result := helpers.GetStringConfig("invalid")
+				result := config.GetStringConfig("invalid")
 
 				Expect(result).To(BeEmpty())
 			})

--- a/database/database.go
+++ b/database/database.go
@@ -3,7 +3,7 @@ package database
 import (
 	"fmt"
 
-	"go-google-scraper-challenge/helpers"
+	"go-google-scraper-challenge/config"
 	"go-google-scraper-challenge/helpers/log"
 
 	"github.com/gin-gonic/gin"
@@ -46,7 +46,7 @@ func GetDatabaseURL() string {
 		viper.GetString("db_username"),
 		viper.GetString("db_password"),
 		viper.GetString("db_host"),
-		helpers.GetStringConfig("db_port"),
-		helpers.GetStringConfig("db_name"),
+		config.GetStringConfig("db_port"),
+		config.GetStringConfig("db_name"),
 	)
 }

--- a/lib/api/v1/controllers/results.go
+++ b/lib/api/v1/controllers/results.go
@@ -30,17 +30,7 @@ func (c *ResultsController) List(ctx *gin.Context) {
 
 	response := []*serializers.ResultResponse{}
 	for _, result := range results {
-		response = append(response, &serializers.ResultResponse{
-			ID:        result.ID,
-			Keyword:   result.Keyword,
-			UserID:    result.UserID,
-			Status:    result.Status,
-			PageCache: result.PageCache,
-			User: &serializers.UserResponse{
-				ID:    result.User.ID,
-				Email: result.User.Email,
-			},
-		})
+		response = append(response, serializers.ResultSerializer{Result: result}.Response())
 	}
 
 	RenderJSON(ctx, http.StatusOK, response)
@@ -80,11 +70,7 @@ func (c *ResultsController) Create(ctx *gin.Context) {
 
 	response := []*serializers.ResultResponse{}
 	for _, result := range *results {
-		response = append(response, &serializers.ResultResponse{
-			ID:      result.ID,
-			Keyword: result.Keyword,
-			UserID:  result.UserID,
-		})
+		response = append(response, serializers.ResultSerializer{Result: &result}.Response())
 	}
 
 	RenderJSON(ctx, http.StatusOK, response)

--- a/lib/api/v1/controllers/results.go
+++ b/lib/api/v1/controllers/results.go
@@ -16,6 +16,39 @@ type ResultsController struct {
 	BaseController
 }
 
+func (c *ResultsController) List(ctx *gin.Context) {
+	if c.EnsureAuthenticatedUser(ctx) != nil {
+		return
+	}
+
+	query := map[string]interface{}{
+		"user_id": c.CurrentUser.ID,
+	}
+	results, err := models.GetResultsBy(query, []string{"User", "AdLinks", "Links"}, "", 0, 100)
+	if err != nil {
+		RenderJSONError(ctx, errors.ErrServerError, err.Error())
+
+		return
+	}
+
+	response := []*serializers.ResultResponse{}
+	for _, result := range results {
+		response = append(response, &serializers.ResultResponse{
+			ID:        result.ID,
+			Keyword:   result.Keyword,
+			UserID:    result.UserID,
+			Status:    result.Status,
+			PageCache: result.PageCache,
+			User: &serializers.UserResponse{
+				ID:    result.User.ID,
+				Email: result.User.Email,
+			},
+		})
+	}
+
+	RenderJSON(ctx, http.StatusOK, response)
+}
+
 func (c *ResultsController) Create(ctx *gin.Context) {
 	if c.EnsureAuthenticatedUser(ctx) != nil {
 		return

--- a/lib/api/v1/controllers/results.go
+++ b/lib/api/v1/controllers/results.go
@@ -21,10 +21,7 @@ func (c *ResultsController) List(ctx *gin.Context) {
 		return
 	}
 
-	query := map[string]interface{}{
-		"user_id": c.CurrentUser.ID,
-	}
-	results, err := models.GetResultsBy(query, []string{"User", "AdLinks", "Links"}, "", 0, 100)
+	results, err := models.GetUserResults(c.CurrentUser.ID, []string{"User", "AdLinks", "Links"})
 	if err != nil {
 		RenderJSONError(ctx, errors.ErrServerError, err.Error())
 

--- a/lib/api/v1/routers/router.go
+++ b/lib/api/v1/routers/router.go
@@ -21,4 +21,5 @@ func ComebineRoutes(engine *gin.Engine) {
 	v1.POST("/register", registerController.Register)
 	v1.POST("/login", authenticationController.Login)
 	v1.POST("/results", resultsController.Create)
+	v1.GET("/results", resultsController.List)
 }

--- a/lib/api/v1/serializers/ad_link.go
+++ b/lib/api/v1/serializers/ad_link.go
@@ -1,0 +1,9 @@
+package serializers
+
+type AdLinkResponse struct {
+	ID       int64  `jsonapi:"primary,ad_link"`
+	ResultID int64  `jsonapi:"attr,result_id"`
+	Type     string `jsonapi:"attr,type"`
+	Position string `jsonapi:"attr,position"`
+	Link     string `jsonapi:"attr,link"`
+}

--- a/lib/api/v1/serializers/base.go
+++ b/lib/api/v1/serializers/base.go
@@ -1,0 +1,8 @@
+package serializers
+
+type RelationshipData struct {
+	Data struct {
+		ID   string `json:"id"`
+		Type string `json:"type"`
+	}
+}

--- a/lib/api/v1/serializers/link.go
+++ b/lib/api/v1/serializers/link.go
@@ -1,0 +1,7 @@
+package serializers
+
+type LinkResponse struct {
+	ID       int64  `jsonapi:"primary,link"`
+	ResultID int64  `jsonapi:"attr,result_id"`
+	Link     string `jsonapi:"attr,link"`
+}

--- a/lib/api/v1/serializers/result.go
+++ b/lib/api/v1/serializers/result.go
@@ -5,17 +5,40 @@ type ResultsResponse struct {
 }
 
 type ResultResponse struct {
-	ID      int64  `jsonapi:"primary,result"`
-	Keyword string `jsonapi:"attr,keyword"`
-	UserID  int64  `jsonapi:"attr,user_id"`
+	ID        int64             `jsonapi:"primary,result"`
+	Keyword   string            `jsonapi:"attr,keyword"`
+	UserID    int64             `jsonapi:"attr,user_id"`
+	Status    string            `jsonapi:"attr,status"`
+	PageCache string            `jsonapi:"attr,page_cache"`
+	User      *UserResponse     `jsonapi:"relation,user,omitempty"`
+	AdLinks   []*AdLinkResponse `jsonapi:"relation,ad_links,omitempty"`
+	Links     []*LinkResponse   `jsonapi:"relation,links,omitempty"`
 }
 
 type ResultsJSONResponse struct {
 	Data []struct {
 		ID         string `json:"id"`
 		Attributes struct {
-			Keyword string `json:"keyword"`
-			UserID  int64  `json:"user_id"`
+			Keyword   string `json:"keyword"`
+			UserID    int64  `json:"user_id"`
+			Status    string `json:"status"`
+			PageCache string `json:"page_cache"`
 		} `json:"attributes"`
+		Relationships struct {
+			User struct {
+				Data RelationshipData
+			} `json:"user"`
+			AdLinks struct {
+				Data RelationshipData
+			} `json:"ad_links"`
+			Links struct {
+				Data RelationshipData
+			} `json:"links"`
+		}
 	} `json:"data"`
+	Included []struct {
+		ID         string                 `json:"id"`
+		Type       string                 `json:"type"`
+		Attributes map[string]interface{} `json:"attributes"`
+	} `json:"included"`
 }

--- a/lib/api/v1/serializers/result.go
+++ b/lib/api/v1/serializers/result.go
@@ -1,6 +1,8 @@
 package serializers
 
-import "go-google-scraper-challenge/lib/models"
+import (
+	"go-google-scraper-challenge/lib/models"
+)
 
 type ResultsResponse struct {
 	Results ResultResponse

--- a/lib/api/v1/serializers/result.go
+++ b/lib/api/v1/serializers/result.go
@@ -1,5 +1,7 @@
 package serializers
 
+import "go-google-scraper-challenge/lib/models"
+
 type ResultsResponse struct {
 	Results ResultResponse
 }
@@ -41,4 +43,24 @@ type ResultsJSONResponse struct {
 		Type       string                 `json:"type"`
 		Attributes map[string]interface{} `json:"attributes"`
 	} `json:"included"`
+}
+
+type ResultSerializer struct {
+	Result *models.Result
+}
+
+func (s ResultSerializer) Response() (response *ResultResponse) {
+	response = &ResultResponse{
+		ID:        s.Result.ID,
+		Keyword:   s.Result.Keyword,
+		UserID:    s.Result.UserID,
+		Status:    s.Result.Status,
+		PageCache: s.Result.PageCache,
+	}
+
+	if s.Result.User != nil {
+		response.User = UserSerializer{User: s.Result.User}.Response()
+	}
+
+	return response
 }

--- a/lib/api/v1/serializers/user.go
+++ b/lib/api/v1/serializers/user.go
@@ -1,6 +1,8 @@
 package serializers
 
-import "go-google-scraper-challenge/lib/models"
+import (
+	"go-google-scraper-challenge/lib/models"
+)
 
 type UserResponse struct {
 	ID    int64  `jsonapi:"primary,user"`

--- a/lib/api/v1/serializers/user.go
+++ b/lib/api/v1/serializers/user.go
@@ -1,0 +1,6 @@
+package serializers
+
+type UserResponse struct {
+	ID    int64  `jsonapi:"primary,user"`
+	Email string `jsonapi:"attr,email"`
+}

--- a/lib/api/v1/serializers/user.go
+++ b/lib/api/v1/serializers/user.go
@@ -1,6 +1,19 @@
 package serializers
 
+import "go-google-scraper-challenge/lib/models"
+
 type UserResponse struct {
 	ID    int64  `jsonapi:"primary,user"`
 	Email string `jsonapi:"attr,email"`
+}
+
+type UserSerializer struct {
+	User *models.User
+}
+
+func (s UserSerializer) Response() (response *UserResponse) {
+	return &UserResponse{
+		ID:    s.User.ID,
+		Email: s.User.Email,
+	}
 }

--- a/lib/models/result.go
+++ b/lib/models/result.go
@@ -80,24 +80,21 @@ func GetResultsByIDs(id []int64) (*[]Result, error) {
 	return results, nil
 }
 
-// GetResultByIDWithRelations retrieves Result by ID with assigned relations. Returns error if ID doesn't exist
-func GetResultByIDWithRelations(id int64) (*Result, error) {
-	result, err := GetResultByID(id)
-	if err != nil {
-		return nil, err
+func GetUserResults(userID int64, preloadRelations []string) (results []*Result, err error) {
+	query := map[string]interface{}{
+		"user_id": userID,
 	}
 
-	result.Links, err = GetLinksByResultID(result.ID)
-	if err != nil {
-		return result, err
+	db := database.GetDB()
+
+	for _, relation := range preloadRelations {
+		db = db.Preload(relation)
 	}
 
-	result.AdLinks, err = GetAdLinksByResultID(result.ID)
-	if err != nil {
-		return result, err
-	}
+	queryResult := db.Find(&results, query)
+	err = queryResult.Error
 
-	return result, nil
+	return results, err
 }
 
 // GetOldestPendingResult retrieves Result with pending status. Return err if no pending result

--- a/lib/models/result.go
+++ b/lib/models/result.go
@@ -60,7 +60,7 @@ func CreateResults(results *[]Result) ([]int64, error) {
 func GetResultByID(id int64) (*Result, error) {
 	result := &Result{}
 
-	queryResult := database.GetDB().First(&result, id)
+	queryResult := database.GetDB().Preload("User").First(&result, id)
 	if queryResult.Error != nil {
 		return nil, queryResult.Error
 	}
@@ -118,8 +118,12 @@ func ContainKeyword(keyword string) func(db *gorm.DB) *gorm.DB {
 	}
 }
 
-func query(condition map[string]interface{}, orderBy string, offset int, limit int) (*gorm.DB, []*Result) {
+func query(condition map[string]interface{}, preloadRelations []string, orderBy string, offset int, limit int) (*gorm.DB, []*Result) {
 	db := database.GetDB()
+
+	for _, relation := range preloadRelations {
+		db = db.Preload(relation)
+	}
 
 	if len(orderBy) > 0 {
 		orderColumn := orderBy
@@ -168,8 +172,8 @@ func query(condition map[string]interface{}, orderBy string, offset int, limit i
 
 // GetResultsBy retrieves Results with given query. Returns empty list if no records exist
 // possible query params are order, limit, offset and result property filter
-func GetResultsBy(condition map[string]interface{}, orderBy string, offset int, limit int) ([]*Result, error) {
-	queryResult, results := query(condition, orderBy, offset, limit)
+func GetResultsBy(condition map[string]interface{}, preloadRelations []string, orderBy string, offset int, limit int) ([]*Result, error) {
+	queryResult, results := query(condition, preloadRelations, orderBy, offset, limit)
 
 	if queryResult.Error != nil {
 		return nil, queryResult.Error
@@ -179,9 +183,9 @@ func GetResultsBy(condition map[string]interface{}, orderBy string, offset int, 
 }
 
 // CountResultsBy count all Results with given query. Returns 0 if no records exist
-func CountResultsBy(condition map[string]interface{}, orderBy string, offset int, limit int) (int64, error) {
+func CountResultsBy(condition map[string]interface{}, preloadRelations []string, orderBy string, offset int, limit int) (int64, error) {
 	count := int64(0)
-	db, _ := query(condition, orderBy, offset, limit)
+	db, _ := query(condition, preloadRelations, orderBy, offset, limit)
 	countResult := db.Count(&count)
 
 	if countResult.Error != nil {

--- a/lib/models/result.go
+++ b/lib/models/result.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"strings"
 
+	"go-google-scraper-challenge/config"
 	"go-google-scraper-challenge/database"
-	"go-google-scraper-challenge/helpers"
 
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -92,7 +92,9 @@ func GetUserResults(userID int64, preloadRelations []string) (results []*Result,
 	}
 
 	queryResult := db.Find(&results, query)
-	err = queryResult.Error
+	if queryResult.Error != nil {
+		return []*Result{}, queryResult.Error
+	}
 
 	return results, err
 }
@@ -141,7 +143,7 @@ func query(condition map[string]interface{}, preloadRelations []string, orderBy 
 
 	limitClause := limit
 	if limit < 0 {
-		limitClause = helpers.GetPaginationPerPage()
+		limitClause = config.GetPaginationPerPage()
 	}
 	db = db.Limit(limitClause)
 

--- a/lib/models/result.go
+++ b/lib/models/result.go
@@ -60,7 +60,7 @@ func CreateResults(results *[]Result) ([]int64, error) {
 func GetResultByID(id int64) (*Result, error) {
 	result := &Result{}
 
-	queryResult := database.GetDB().Preload("User").First(&result, id)
+	queryResult := database.GetDB().First(&result, id)
 	if queryResult.Error != nil {
 		return nil, queryResult.Error
 	}

--- a/lib/models/result_test.go
+++ b/lib/models/result_test.go
@@ -329,7 +329,7 @@ var _ = Describe("Result", func() {
 						result2 := FabricateResult(user)
 						result3 := FabricateResult(user)
 
-						results, err := models.GetResultsBy(map[string]interface{}{}, "", 0, 2)
+						results, err := models.GetResultsBy(map[string]interface{}{}, []string{}, "", 0, 2)
 						if err != nil {
 							Fail("Failed to get results with User Id")
 						}
@@ -349,7 +349,7 @@ var _ = Describe("Result", func() {
 						FabricateResult(user)
 						FabricateResult(user)
 
-						_, err := models.GetResultsBy(map[string]interface{}{}, "", 0, 2)
+						_, err := models.GetResultsBy(map[string]interface{}{}, []string{}, "", 0, 2)
 						Expect(err).To(BeNil())
 					})
 				})
@@ -361,7 +361,7 @@ var _ = Describe("Result", func() {
 						result2 := FabricateResult(user)
 						result3 := FabricateResult(user)
 
-						results, err := models.GetResultsBy(map[string]interface{}{}, "", 0, 0)
+						results, err := models.GetResultsBy(map[string]interface{}{}, []string{}, "", 0, 0)
 						if err != nil {
 							Fail("Failed to get results with User Id")
 						}
@@ -380,7 +380,7 @@ var _ = Describe("Result", func() {
 						FabricateResult(user)
 						FabricateResult(user)
 
-						_, err := models.GetResultsBy(map[string]interface{}{}, "", 0, 0)
+						_, err := models.GetResultsBy(map[string]interface{}{}, []string{}, "", 0, 0)
 						Expect(err).To(BeNil())
 					})
 				})
@@ -394,7 +394,7 @@ var _ = Describe("Result", func() {
 						result2 := FabricateResult(user)
 						result3 := FabricateResult(user)
 
-						results, err := models.GetResultsBy(map[string]interface{}{}, "", 1, 0)
+						results, err := models.GetResultsBy(map[string]interface{}{}, []string{}, "", 1, 0)
 						if err != nil {
 							Fail("Failed to get results with User Id")
 						}
@@ -414,7 +414,7 @@ var _ = Describe("Result", func() {
 						FabricateResult(user)
 						FabricateResult(user)
 
-						_, err := models.GetResultsBy(map[string]interface{}{}, "", 1, 0)
+						_, err := models.GetResultsBy(map[string]interface{}{}, []string{}, "", 1, 0)
 						Expect(err).To(BeNil())
 					})
 				})
@@ -426,7 +426,7 @@ var _ = Describe("Result", func() {
 						result2 := FabricateResult(user)
 						result3 := FabricateResult(user)
 
-						results, err := models.GetResultsBy(map[string]interface{}{}, "", 0, 0)
+						results, err := models.GetResultsBy(map[string]interface{}{}, []string{}, "", 0, 0)
 						if err != nil {
 							Fail("Failed to get results with User Id")
 						}
@@ -445,7 +445,7 @@ var _ = Describe("Result", func() {
 						FabricateResult(user)
 						FabricateResult(user)
 
-						_, err := models.GetResultsBy(map[string]interface{}{}, "", 0, 0)
+						_, err := models.GetResultsBy(map[string]interface{}{}, []string{}, "", 0, 0)
 						Expect(err).To(BeNil())
 					})
 				})
@@ -462,7 +462,7 @@ var _ = Describe("Result", func() {
 					query := map[string]interface{}{
 						"user_id": user.ID,
 					}
-					results, err := models.GetResultsBy(query, "", 0, 0)
+					results, err := models.GetResultsBy(query, []string{}, "", 0, 0)
 					if err != nil {
 						Fail("Failed to get results with User Id")
 					}
@@ -486,7 +486,7 @@ var _ = Describe("Result", func() {
 					query := map[string]interface{}{
 						"user_id": user.ID,
 					}
-					_, err := models.GetResultsBy(query, "", 0, 0)
+					_, err := models.GetResultsBy(query, []string{}, "", 0, 0)
 					Expect(err).To(BeNil())
 				})
 			})
@@ -502,7 +502,7 @@ var _ = Describe("Result", func() {
 					query := map[string]interface{}{
 						"user_id": user.ID,
 					}
-					results, err := models.GetResultsBy(query, "", 0, 0)
+					results, err := models.GetResultsBy(query, []string{}, "", 0, 0)
 					if err != nil {
 						Fail("Failed to get results with User Id")
 					}
@@ -526,7 +526,7 @@ var _ = Describe("Result", func() {
 					query := map[string]interface{}{
 						"user_id": user.ID,
 					}
-					_, err := models.GetResultsBy(query, "", 0, 0)
+					_, err := models.GetResultsBy(query, []string{}, "", 0, 0)
 					Expect(err).To(BeNil())
 				})
 			})
@@ -541,7 +541,7 @@ var _ = Describe("Result", func() {
 					query := map[string]interface{}{
 						"keyword": "keyword",
 					}
-					results, err := models.GetResultsBy(query, "", 0, 0)
+					results, err := models.GetResultsBy(query, []string{}, "", 0, 0)
 					if err != nil {
 						Fail("Failed to get results with User Id")
 					}
@@ -564,7 +564,7 @@ var _ = Describe("Result", func() {
 					query := map[string]interface{}{
 						"keyword": "keyword",
 					}
-					_, err := models.GetResultsBy(query, "", 0, 0)
+					_, err := models.GetResultsBy(query, []string{}, "", 0, 0)
 					Expect(err).To(BeNil())
 				})
 			})
@@ -575,7 +575,7 @@ var _ = Describe("Result", func() {
 					result1 := FabricateResult(user)
 					result2 := FabricateResult(user)
 
-					results, err := models.GetResultsBy(map[string]interface{}{}, "-id", 0, 0)
+					results, err := models.GetResultsBy(map[string]interface{}{}, []string{}, "-id", 0, 0)
 					if err != nil {
 						Fail("Failed to get results with User Id")
 					}
@@ -594,7 +594,7 @@ var _ = Describe("Result", func() {
 					FabricateResult(user)
 					FabricateResult(user)
 
-					_, err := models.GetResultsBy(map[string]interface{}{}, "-id", 0, 0)
+					_, err := models.GetResultsBy(map[string]interface{}{}, []string{}, "-id", 0, 0)
 					Expect(err).To(BeNil())
 				})
 			})
@@ -607,7 +607,7 @@ var _ = Describe("Result", func() {
 					result1 := FabricateResult(user)
 					result2 := FabricateResult(user)
 
-					results, err := models.GetResultsBy(map[string]interface{}{}, "", -1, 0)
+					results, err := models.GetResultsBy(map[string]interface{}{}, []string{}, "", -1, 0)
 					if err != nil {
 						Fail("Failed to get results with User Id")
 					}
@@ -625,7 +625,7 @@ var _ = Describe("Result", func() {
 					FabricateResult(user)
 					FabricateResult(user)
 
-					_, err := models.GetResultsBy(map[string]interface{}{}, "", -1, 0)
+					_, err := models.GetResultsBy(map[string]interface{}{}, []string{}, "", -1, 0)
 					Expect(err).To(BeNil())
 				})
 			})
@@ -636,7 +636,7 @@ var _ = Describe("Result", func() {
 					result1 := FabricateResult(user)
 					result2 := FabricateResult(user)
 
-					results, err := models.GetResultsBy(map[string]interface{}{}, "", 0, -1)
+					results, err := models.GetResultsBy(map[string]interface{}{}, []string{}, "", 0, -1)
 					if err != nil {
 						Fail("Failed to get results with User Id")
 					}
@@ -654,7 +654,7 @@ var _ = Describe("Result", func() {
 					FabricateResult(user)
 					FabricateResult(user)
 
-					_, err := models.GetResultsBy(map[string]interface{}{}, "", 0, -1)
+					_, err := models.GetResultsBy(map[string]interface{}{}, []string{}, "", 0, -1)
 					Expect(err).To(BeNil())
 				})
 			})
@@ -668,7 +668,7 @@ var _ = Describe("Result", func() {
 					query := map[string]interface{}{
 						"user_id": 999,
 					}
-					results, err := models.GetResultsBy(query, "", 0, 0)
+					results, err := models.GetResultsBy(query, []string{}, "", 0, 0)
 					if err != nil {
 						Fail("Failed to get results with User Id")
 					}
@@ -684,7 +684,7 @@ var _ = Describe("Result", func() {
 					query := map[string]interface{}{
 						"user_id": 999,
 					}
-					_, err := models.GetResultsBy(query, "", 0, 0)
+					_, err := models.GetResultsBy(query, []string{}, "", 0, 0)
 					Expect(err).To(BeNil())
 				})
 			})
@@ -703,7 +703,7 @@ var _ = Describe("Result", func() {
 				query := map[string]interface{}{
 					"user_id": user.ID,
 				}
-				count, err := models.CountResultsBy(query, "", 0, 0)
+				count, err := models.CountResultsBy(query, []string{}, "", 0, 0)
 				if err != nil {
 					Fail("Failed to count results with User Id")
 				}
@@ -721,7 +721,7 @@ var _ = Describe("Result", func() {
 				query := map[string]interface{}{
 					"user_id": user.ID,
 				}
-				_, err := models.CountResultsBy(query, "", 0, 0)
+				_, err := models.CountResultsBy(query, []string{}, "", 0, 0)
 				Expect(err).To(BeNil())
 			})
 		})
@@ -735,7 +735,7 @@ var _ = Describe("Result", func() {
 				query := map[string]interface{}{
 					"user_id": 999,
 				}
-				count, err := models.CountResultsBy(query, "", 0, 0)
+				count, err := models.CountResultsBy(query, []string{}, "", 0, 0)
 				if err != nil {
 					Fail("Failed to count results with User Id")
 				}
@@ -751,7 +751,7 @@ var _ = Describe("Result", func() {
 				query := map[string]interface{}{
 					"user_id": 999,
 				}
-				_, err := models.CountResultsBy(query, "", 0, 0)
+				_, err := models.CountResultsBy(query, []string{}, "", 0, 0)
 				Expect(err).To(BeNil())
 			})
 		})

--- a/lib/models/result_test.go
+++ b/lib/models/result_test.go
@@ -691,6 +691,66 @@ var _ = Describe("Result", func() {
 		})
 	})
 
+	Describe("#GetUserResults", func() {
+		Context("given valid params", func() {
+			Context("given user ID with results", func() {
+				It("returns a list of results that belongs to the user", func() {
+					user := FabricateUser(faker.Email(), faker.Password())
+					anotherUser := FabricateUser(faker.Email(), faker.Password())
+					result1 := FabricateResult(user)
+					result2 := FabricateResult(user)
+					result3 := FabricateResult(anotherUser)
+
+					results, err := models.GetUserResults(user.ID, []string{})
+
+					Expect(err).To(BeNil())
+
+					var resultIDs []int64
+					for _, r := range results {
+						resultIDs = append(resultIDs, r.ID)
+					}
+
+					Expect(resultIDs).To(ConsistOf(result1.ID, result2.ID))
+					Expect(resultIDs).NotTo(ConsistOf(result3.ID))
+				})
+
+				Context("given an array of preload relations", func() {
+					It("returns an array of results with relations", func() {
+						user := FabricateUser(faker.Email(), faker.Password())
+						anotherUser := FabricateUser(faker.Email(), faker.Password())
+						FabricateResult(user)
+						FabricateResult(user)
+						FabricateResult(anotherUser)
+
+						results, err := models.GetUserResults(user.ID, []string{"User"})
+
+						Expect(err).To(BeNil())
+
+						for _, r := range results {
+							Expect(r.User).ToNot(BeNil())
+							Expect(r.User.ID).To(Equal(user.ID))
+						}
+					})
+				})
+			})
+
+			Context("given user ID without results", func() {
+				It("returns a blank array of result", func() {
+					user := FabricateUser(faker.Email(), faker.Password())
+
+					results, err := models.GetUserResults(user.ID, []string{})
+
+					Expect(err).To(BeNil())
+					Expect(results).To(HaveLen(0))
+				})
+			})
+		})
+
+		Context("given invalid params", func() {
+
+		})
+	})
+
 	Describe("#CountResultsBy", func() {
 		Context("given a valid user id", func() {
 			It("returns the correct number of user results", func() {

--- a/lib/models/result_test.go
+++ b/lib/models/result_test.go
@@ -747,7 +747,14 @@ var _ = Describe("Result", func() {
 		})
 
 		Context("given invalid params", func() {
+			Context("given an INVALID user ID", func() {
+				It("returns a blank array of result", func() {
+					results, err := models.GetUserResults(999, []string{})
 
+					Expect(err).To(BeNil())
+					Expect(results).To(HaveLen(0))
+				})
+			})
 		})
 	})
 

--- a/test/controller.go
+++ b/test/controller.go
@@ -37,6 +37,18 @@ func MakeAuthenticatedFormRequest(method string, url string, formData url.Values
 	return MakeRequest(request)
 }
 
+func MakeAuthenticatedJSONRequest(method string, url string, body io.Reader, user *models.User) (*gin.Context, *httptest.ResponseRecorder) {
+	request := HTTPRequest(method, url, body)
+	request.Header.Add("Content-Type", "application/json")
+
+	if user != nil {
+		accessToken := FabricateAuthToken(user.ID)
+		request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", accessToken))
+	}
+
+	return MakeRequest(request)
+}
+
 func MakeFormRequest(method string, url string, formData url.Values) (*gin.Context, *httptest.ResponseRecorder) {
 	request := buildFormRequest(method, url, nil, formData)
 


### PR DESCRIPTION
Resolves https://github.com/carryall/go-google-scraper-challenge/issues/8

## What happened 👀

- Add a result list `GET /results` API endpoint
- Move the config helper to `config` package to avoid cycle import issue
- Refactor the serializer to reduce the logic in controller, now we can assign the model pointer to a serializer and let the serializer generate the response

## Insight 📝

N/A

## Proof Of Work 📹

The result list API response with the result that belongs to the logged in user and with user relation
(no `AdLink` and `Link` relation for now as the scraping doesn't work yet)


https://user-images.githubusercontent.com/1772999/173036555-c63a0bbb-865d-4bb0-b043-e8afe9af849c.mov


