### PR TITLE
[#101] Bump Tailwind package version to resolve fail dependencies installation on CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "devDependencies": {
     "@snowpack/plugin-postcss": "1.4.3",
     "@snowpack/plugin-sass": "1.4.0",
-    "@tailwindcss/forms": "0.5.1",
+    "@tailwindcss/forms": "0.5.2",
     "@types/node": "17.0.34",
     "autoprefixer": "10.2.6",
     "eslint": "7.29.0",
@@ -22,6 +22,6 @@
     "postcss": "8.3.5",
     "prettier": "2.3.2",
     "snowpack": "3.7.1",
-    "tailwindcss": "2.2.7"
+    "tailwindcss": "3.1.1"
   }
 }


### PR DESCRIPTION
https://github.com/carryall/go-google-scraper-challenge/issues/101

## What happened 👀

The test fails because the dependency conflict

![Screen Shot 2565-06-13 at 12 25 48](https://user-images.githubusercontent.com/1772999/173285912-77186311-066c-4afb-b586-1481dccc24da.png)

## Insight 📝

N/A

## Proof Of Work 📹

The test should pass
