### PR TITLE
[#98] Refactor the make request functions for controller

### DIFF
--- a/lib/api/v1/controllers/authentication_test.go
+++ b/lib/api/v1/controllers/authentication_test.go
@@ -31,7 +31,7 @@ var _ = Describe("AuthenticationController", func() {
 					"grant_type":    {"password"},
 				}
 
-				ctx, response := MakeFormRequest("POST", "/login", formData)
+				ctx, response := MakeFormRequest("POST", "/login", formData, nil)
 
 				authenticationController := controllers.AuthenticationController{}
 				authenticationController.Login(ctx)
@@ -51,7 +51,7 @@ var _ = Describe("AuthenticationController", func() {
 					"grant_type":    {"password"},
 				}
 
-				ctx, response := MakeFormRequest("POST", "/login", formData)
+				ctx, response := MakeFormRequest("POST", "/login", formData, nil)
 
 				authenticationController := controllers.AuthenticationController{}
 				authenticationController.Login(ctx)
@@ -80,7 +80,7 @@ var _ = Describe("AuthenticationController", func() {
 						"client_secret": {authClient.ClientSecret},
 					}
 
-					ctx, response := MakeFormRequest("POST", "/login", formData)
+					ctx, response := MakeFormRequest("POST", "/login", formData, nil)
 
 					authenticationController := controllers.AuthenticationController{}
 					authenticationController.Login(ctx)
@@ -106,7 +106,7 @@ var _ = Describe("AuthenticationController", func() {
 						"client_secret": {authClient.ClientSecret},
 					}
 
-					ctx, response := MakeFormRequest("POST", "/login", formData)
+					ctx, response := MakeFormRequest("POST", "/login", formData, nil)
 
 					authenticationController := controllers.AuthenticationController{}
 					authenticationController.Login(ctx)
@@ -132,7 +132,7 @@ var _ = Describe("AuthenticationController", func() {
 						"client_id":  {authClient.ClientID},
 					}
 
-					ctx, response := MakeFormRequest("POST", "/login", formData)
+					ctx, response := MakeFormRequest("POST", "/login", formData, nil)
 
 					authenticationController := controllers.AuthenticationController{}
 					authenticationController.Login(ctx)
@@ -158,7 +158,7 @@ var _ = Describe("AuthenticationController", func() {
 						"grant_type":    {"password"},
 					}
 
-					ctx, response := MakeFormRequest("POST", "/login", formData)
+					ctx, response := MakeFormRequest("POST", "/login", formData, nil)
 
 					authenticationController := controllers.AuthenticationController{}
 					authenticationController.Login(ctx)
@@ -184,7 +184,7 @@ var _ = Describe("AuthenticationController", func() {
 						"grant_type":    {"password"},
 					}
 
-					ctx, response := MakeFormRequest("POST", "/login", formData)
+					ctx, response := MakeFormRequest("POST", "/login", formData, nil)
 
 					authenticationController := controllers.AuthenticationController{}
 					authenticationController.Login(ctx)
@@ -213,7 +213,7 @@ var _ = Describe("AuthenticationController", func() {
 						"grant_type":    {"password"},
 					}
 
-					ctx, response := MakeFormRequest("POST", "/login", formData)
+					ctx, response := MakeFormRequest("POST", "/login", formData, nil)
 
 					authenticationController := controllers.AuthenticationController{}
 					authenticationController.Login(ctx)
@@ -241,7 +241,7 @@ var _ = Describe("AuthenticationController", func() {
 						"grant_type":    {"password"},
 					}
 
-					ctx, response := MakeFormRequest("POST", "/login", formData)
+					ctx, response := MakeFormRequest("POST", "/login", formData, nil)
 
 					authenticationController := controllers.AuthenticationController{}
 					authenticationController.Login(ctx)
@@ -269,7 +269,7 @@ var _ = Describe("AuthenticationController", func() {
 						"grant_type":    {"password"},
 					}
 
-					ctx, response := MakeFormRequest("POST", "/login", formData)
+					ctx, response := MakeFormRequest("POST", "/login", formData, nil)
 
 					authenticationController := controllers.AuthenticationController{}
 					authenticationController.Login(ctx)
@@ -296,7 +296,7 @@ var _ = Describe("AuthenticationController", func() {
 						"grant_type":    {"password"},
 					}
 
-					ctx, response := MakeFormRequest("POST", "/login", formData)
+					ctx, response := MakeFormRequest("POST", "/login", formData, nil)
 
 					authenticationController := controllers.AuthenticationController{}
 					authenticationController.Login(ctx)
@@ -324,7 +324,7 @@ var _ = Describe("AuthenticationController", func() {
 						"grant_type":    {"invalid grant type"},
 					}
 
-					ctx, response := MakeFormRequest("POST", "/login", formData)
+					ctx, response := MakeFormRequest("POST", "/login", formData, nil)
 
 					authenticationController := controllers.AuthenticationController{}
 					authenticationController.Login(ctx)

--- a/lib/api/v1/controllers/oauth/clients_test.go
+++ b/lib/api/v1/controllers/oauth/clients_test.go
@@ -15,7 +15,7 @@ import (
 var _ = Describe("OAuthClientsController", func() {
 	Describe("POST /oauth/clients", func() {
 		It("returns status OK", func() {
-			ctx, response := MakeJSONRequest("POST", "/oauth/clients", nil)
+			ctx, response := MakeJSONRequest("POST", "/oauth/clients", nil, nil, nil)
 
 			oauthClientsController := controllers.OAuthClientsController{}
 			oauthClientsController.Create(ctx)
@@ -27,7 +27,7 @@ var _ = Describe("OAuthClientsController", func() {
 		})
 
 		It("returns correct response body", func() {
-			ctx, response := MakeJSONRequest("POST", "/oauth/clients", nil)
+			ctx, response := MakeJSONRequest("POST", "/oauth/clients", nil, nil, nil)
 
 			oauthClientsController := controllers.OAuthClientsController{}
 			oauthClientsController.Create(ctx)

--- a/lib/api/v1/controllers/result_test.go
+++ b/lib/api/v1/controllers/result_test.go
@@ -21,7 +21,7 @@ var _ = Describe("ResultsController", func() {
 		Context("given an authenticated request", func() {
 			It("returns status OK", func() {
 				user := FabricateUser(faker.Email(), faker.Password())
-				ctx, response := test.MakeAuthenticatedJSONRequest("GET", "/results", nil, user)
+				ctx, response := test.MakeJSONRequest("GET", "/results", nil, nil, user)
 
 				resultsController := controllers.ResultsController{}
 				resultsController.List(ctx)
@@ -34,7 +34,7 @@ var _ = Describe("ResultsController", func() {
 				anotherUser := FabricateUser(faker.Email(), faker.Password())
 				expectedResult := FabricateResult(user)
 				FabricateResult(anotherUser)
-				ctx, response := test.MakeAuthenticatedJSONRequest("GET", "/results", nil, user)
+				ctx, response := test.MakeJSONRequest("GET", "/results", nil, nil, user)
 
 				resultsController := controllers.ResultsController{}
 				resultsController.List(ctx)
@@ -56,7 +56,7 @@ var _ = Describe("ResultsController", func() {
 
 		Context("given an unauthenticated request", func() {
 			It("returns status Unauthorized", func() {
-				ctx, response := test.MakeAuthenticatedJSONRequest("GET", "/results", nil, nil)
+				ctx, response := test.MakeJSONRequest("GET", "/results", nil, nil, nil)
 
 				resultsController := controllers.ResultsController{}
 				resultsController.List(ctx)
@@ -80,7 +80,7 @@ var _ = Describe("ResultsController", func() {
 					user := FabricateUser(faker.Email(), faker.Password())
 					header, body := CreateRequestInfoFormFile("test/fixtures/files/valid.csv")
 
-					ctx, response := MakeUploadRequest("POST", "/results", header, body, user)
+					ctx, response := MakeJSONRequest("POST", "/results", header, body, user)
 
 					resultsController := controllers.ResultsController{}
 					resultsController.Create(ctx)
@@ -92,7 +92,7 @@ var _ = Describe("ResultsController", func() {
 					user := FabricateUser(faker.Email(), faker.Password())
 					header, body := CreateRequestInfoFormFile("test/fixtures/files/valid.csv")
 
-					ctx, response := MakeUploadRequest("POST", "/results", header, body, user)
+					ctx, response := MakeJSONRequest("POST", "/results", header, body, user)
 
 					resultsController := controllers.ResultsController{}
 					resultsController.Create(ctx)
@@ -111,7 +111,7 @@ var _ = Describe("ResultsController", func() {
 					user := FabricateUser(faker.Email(), faker.Password())
 					header, body := CreateRequestInfoFormFile("test/fixtures/files/empty.csv")
 
-					ctx, response := MakeUploadRequest("POST", "/results", header, body, user)
+					ctx, response := MakeJSONRequest("POST", "/results", header, body, user)
 
 					resultsController := controllers.ResultsController{}
 					resultsController.Create(ctx)
@@ -132,7 +132,7 @@ var _ = Describe("ResultsController", func() {
 					user := FabricateUser(faker.Email(), faker.Password())
 					header, body := CreateRequestInfoFormFile("test/fixtures/files/invalid.csv")
 
-					ctx, response := MakeUploadRequest("POST", "/results", header, body, user)
+					ctx, response := MakeJSONRequest("POST", "/results", header, body, user)
 
 					resultsController := controllers.ResultsController{}
 					resultsController.Create(ctx)
@@ -153,7 +153,7 @@ var _ = Describe("ResultsController", func() {
 					user := FabricateUser(faker.Email(), faker.Password())
 					header, body := CreateRequestInfoFormFile("test/fixtures/files/text.txt")
 
-					ctx, response := MakeUploadRequest("POST", "/results", header, body, user)
+					ctx, response := MakeJSONRequest("POST", "/results", header, body, user)
 
 					resultsController := controllers.ResultsController{}
 					resultsController.Create(ctx)
@@ -174,7 +174,7 @@ var _ = Describe("ResultsController", func() {
 			It("returns status Unauthorized", func() {
 				header, body := CreateRequestInfoFormFile("test/fixtures/files/valid.csv")
 
-				ctx, response := MakeUploadRequest("POST", "/results", header, body, nil)
+				ctx, response := MakeJSONRequest("POST", "/results", header, body, nil)
 
 				resultsController := controllers.ResultsController{}
 				resultsController.Create(ctx)

--- a/lib/api/v1/controllers/users_test.go
+++ b/lib/api/v1/controllers/users_test.go
@@ -28,7 +28,7 @@ var _ = Describe("UsersController", func() {
 					"client_secret": {authClient.ClientSecret},
 				}
 
-				ctx, response := MakeFormRequest("POST", "/register", formData)
+				ctx, response := MakeFormRequest("POST", "/register", formData, nil)
 
 				usersController := controllers.UsersController{}
 				usersController.Register(ctx)
@@ -45,7 +45,7 @@ var _ = Describe("UsersController", func() {
 					"client_secret": {authClient.ClientSecret},
 				}
 
-				ctx, response := MakeFormRequest("POST", "/register", formData)
+				ctx, response := MakeFormRequest("POST", "/register", formData, nil)
 
 				usersController := controllers.UsersController{}
 				usersController.Register(ctx)
@@ -72,7 +72,7 @@ var _ = Describe("UsersController", func() {
 							"client_secret": {authClient.ClientSecret},
 						}
 
-						ctx, response := MakeFormRequest("POST", "/register", formData)
+						ctx, response := MakeFormRequest("POST", "/register", formData, nil)
 
 						usersController := controllers.UsersController{}
 						usersController.Register(ctx)
@@ -89,7 +89,7 @@ var _ = Describe("UsersController", func() {
 							"client_secret": {authClient.ClientSecret},
 						}
 
-						ctx, response := MakeFormRequest("POST", "/register", formData)
+						ctx, response := MakeFormRequest("POST", "/register", formData, nil)
 
 						usersController := controllers.UsersController{}
 						usersController.Register(ctx)
@@ -113,7 +113,7 @@ var _ = Describe("UsersController", func() {
 							"client_secret": {authClient.ClientSecret},
 						}
 
-						ctx, response := MakeFormRequest("POST", "/register", formData)
+						ctx, response := MakeFormRequest("POST", "/register", formData, nil)
 
 						usersController := controllers.UsersController{}
 						usersController.Register(ctx)
@@ -130,7 +130,7 @@ var _ = Describe("UsersController", func() {
 							"client_secret": {authClient.ClientSecret},
 						}
 
-						ctx, response := MakeFormRequest("POST", "/register", formData)
+						ctx, response := MakeFormRequest("POST", "/register", formData, nil)
 
 						usersController := controllers.UsersController{}
 						usersController.Register(ctx)
@@ -156,7 +156,7 @@ var _ = Describe("UsersController", func() {
 							"client_secret": {""},
 						}
 
-						ctx, response := MakeFormRequest("POST", "/register", formData)
+						ctx, response := MakeFormRequest("POST", "/register", formData, nil)
 
 						usersController := controllers.UsersController{}
 						usersController.Register(ctx)
@@ -173,7 +173,7 @@ var _ = Describe("UsersController", func() {
 							"client_secret": {""},
 						}
 
-						ctx, response := MakeFormRequest("POST", "/register", formData)
+						ctx, response := MakeFormRequest("POST", "/register", formData, nil)
 
 						usersController := controllers.UsersController{}
 						usersController.Register(ctx)
@@ -197,7 +197,7 @@ var _ = Describe("UsersController", func() {
 							"client_secret": {"invalid secret"},
 						}
 
-						ctx, response := MakeFormRequest("POST", "/register", formData)
+						ctx, response := MakeFormRequest("POST", "/register", formData, nil)
 
 						usersController := controllers.UsersController{}
 						usersController.Register(ctx)
@@ -214,7 +214,7 @@ var _ = Describe("UsersController", func() {
 							"client_secret": {"invalid secret"},
 						}
 
-						ctx, response := MakeFormRequest("POST", "/register", formData)
+						ctx, response := MakeFormRequest("POST", "/register", formData, nil)
 
 						usersController := controllers.UsersController{}
 						usersController.Register(ctx)
@@ -240,7 +240,7 @@ var _ = Describe("UsersController", func() {
 							"client_secret": {authClient.ClientSecret},
 						}
 
-						ctx, response := MakeFormRequest("POST", "/register", formData)
+						ctx, response := MakeFormRequest("POST", "/register", formData, nil)
 
 						usersController := controllers.UsersController{}
 						usersController.Register(ctx)
@@ -257,7 +257,7 @@ var _ = Describe("UsersController", func() {
 							"client_secret": {authClient.ClientSecret},
 						}
 
-						ctx, response := MakeFormRequest("POST", "/register", formData)
+						ctx, response := MakeFormRequest("POST", "/register", formData, nil)
 
 						usersController := controllers.UsersController{}
 						usersController.Register(ctx)
@@ -281,7 +281,7 @@ var _ = Describe("UsersController", func() {
 							"client_secret": {authClient.ClientSecret},
 						}
 
-						ctx, response := MakeFormRequest("POST", "/register", formData)
+						ctx, response := MakeFormRequest("POST", "/register", formData, nil)
 
 						usersController := controllers.UsersController{}
 						usersController.Register(ctx)
@@ -298,7 +298,7 @@ var _ = Describe("UsersController", func() {
 							"client_secret": {authClient.ClientSecret},
 						}
 
-						ctx, response := MakeFormRequest("POST", "/register", formData)
+						ctx, response := MakeFormRequest("POST", "/register", formData, nil)
 
 						usersController := controllers.UsersController{}
 						usersController.Register(ctx)
@@ -324,7 +324,7 @@ var _ = Describe("UsersController", func() {
 							"client_secret": {authClient.ClientSecret},
 						}
 
-						ctx, response := MakeFormRequest("POST", "/register", formData)
+						ctx, response := MakeFormRequest("POST", "/register", formData, nil)
 
 						usersController := controllers.UsersController{}
 						usersController.Register(ctx)
@@ -341,7 +341,7 @@ var _ = Describe("UsersController", func() {
 							"client_secret": {authClient.ClientSecret},
 						}
 
-						ctx, response := MakeFormRequest("POST", "/register", formData)
+						ctx, response := MakeFormRequest("POST", "/register", formData, nil)
 
 						usersController := controllers.UsersController{}
 						usersController.Register(ctx)
@@ -365,7 +365,7 @@ var _ = Describe("UsersController", func() {
 							"client_secret": {authClient.ClientSecret},
 						}
 
-						ctx, response := MakeFormRequest("POST", "/register", formData)
+						ctx, response := MakeFormRequest("POST", "/register", formData, nil)
 
 						usersController := controllers.UsersController{}
 						usersController.Register(ctx)
@@ -382,7 +382,7 @@ var _ = Describe("UsersController", func() {
 							"client_secret": {authClient.ClientSecret},
 						}
 
-						ctx, response := MakeFormRequest("POST", "/register", formData)
+						ctx, response := MakeFormRequest("POST", "/register", formData, nil)
 
 						usersController := controllers.UsersController{}
 						usersController.Register(ctx)

--- a/test/controller.go
+++ b/test/controller.go
@@ -15,30 +15,8 @@ import (
 	"github.com/onsi/ginkgo"
 )
 
-func MakeUploadRequest(method string, url string, header http.Header, body io.Reader, user *models.User) (*gin.Context, *httptest.ResponseRecorder) {
+func MakeJSONRequest(method string, url string, header http.Header, body io.Reader, user *models.User) (*gin.Context, *httptest.ResponseRecorder) {
 	request := buildRequest(method, url, header, body)
-
-	if user != nil {
-		accessToken := FabricateAuthToken(user.ID)
-		request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", accessToken))
-	}
-
-	return MakeRequest(request)
-}
-
-func MakeAuthenticatedFormRequest(method string, url string, formData url.Values, user *models.User) (*gin.Context, *httptest.ResponseRecorder) {
-	request := buildFormRequest(method, url, nil, formData)
-
-	if user != nil {
-		accessToken := FabricateAuthToken(user.ID)
-		request.Header.Set("Authorization", fmt.Sprintf("Bearer %s", accessToken))
-	}
-
-	return MakeRequest(request)
-}
-
-func MakeAuthenticatedJSONRequest(method string, url string, body io.Reader, user *models.User) (*gin.Context, *httptest.ResponseRecorder) {
-	request := HTTPRequest(method, url, body)
 	request.Header.Add("Content-Type", "application/json")
 
 	if user != nil {
@@ -49,15 +27,8 @@ func MakeAuthenticatedJSONRequest(method string, url string, body io.Reader, use
 	return MakeRequest(request)
 }
 
-func MakeFormRequest(method string, url string, formData url.Values) (*gin.Context, *httptest.ResponseRecorder) {
+func MakeFormRequest(method string, url string, formData url.Values, user *models.User) (*gin.Context, *httptest.ResponseRecorder) {
 	request := buildFormRequest(method, url, nil, formData)
-
-	return MakeRequest(request)
-}
-
-func MakeJSONRequest(method string, url string, body io.Reader) (*gin.Context, *httptest.ResponseRecorder) {
-	request := HTTPRequest(method, url, body)
-	request.Header.Add("Content-Type", "application/json")
 
 	return MakeRequest(request)
 }


### PR DESCRIPTION
Resolves https://github.com/carryall/go-google-scraper-challenge/issues/98

## What happened 👀

Refactor the test helper functions for controller tests so we can reuse the same function
- Only 2 functions were provided, one for JSON request and another for form request
- Authenticated and unauthenticated depend on the last param (the user pointer)

## Insight 📝

N/A

## Proof Of Work 📹

Tests passed
