### PR TITLE
[#63][API] As a user, I can see a detail of the search result 

### DIFF
--- a/errors/api.go
+++ b/errors/api.go
@@ -11,6 +11,7 @@ var (
 	ErrInvalidAuthClient   = errors.New("invalid_authentication_client")
 	ErrUnauthorizedUser    = errors.New("unauthorized_user")
 	ErrUnProcessableEntity = errors.New("unprocessable_entity")
+	ErrNotFound            = errors.New("not_found")
 	ErrServerError         = errors.New("server_error")
 )
 
@@ -20,6 +21,7 @@ var Titles = map[error]string{
 	ErrInvalidAuthClient:   "Invalid Authentication Client",
 	ErrUnauthorizedUser:    "Unauthorized User",
 	ErrUnProcessableEntity: "Unprocessable Entity",
+	ErrNotFound:            "Not Found",
 	ErrServerError:         "Internal Server Error",
 }
 
@@ -29,6 +31,7 @@ var Descriptions = map[error]string{
 	ErrInvalidAuthClient:   "Authentication client is invalid",
 	ErrUnauthorizedUser:    "The user is not authorized",
 	ErrUnProcessableEntity: "The request is unprocessable",
+	ErrNotFound:            "Cannot find the resource you are looking for",
 	ErrServerError:         "Something went wrong",
 }
 
@@ -38,5 +41,6 @@ var StatusCodes = map[error]int{
 	ErrInvalidAuthClient:   http.StatusUnauthorized,
 	ErrUnauthorizedUser:    http.StatusUnauthorized,
 	ErrUnProcessableEntity: http.StatusUnprocessableEntity,
+	ErrNotFound:            http.StatusNotFound,
 	ErrServerError:         http.StatusInternalServerError,
 }

--- a/lib/api/v1/controllers/result_test.go
+++ b/lib/api/v1/controllers/result_test.go
@@ -52,11 +52,12 @@ var _ = Describe("ResultsController", func() {
 				Expect(jsonArrayResponse.Included[0].Attributes["email"]).To(Equal(user.Email))
 			})
 
-			It("returns relations of results", func() {
+			It("returns number of result relations", func() {
 				user := FabricateUser(faker.Email(), faker.Password())
 				result := FabricateResult(user)
-				adLink := FabricateAdLink(result)
-				link := FabricateLink(result)
+				FabricateLink(result)
+				FabricateAdLink(result)
+				FabricateAdLink(result)
 				ctx, response := MakeJSONRequest("GET", "/results", nil, nil, user)
 
 				resultsController := controllers.ResultsController{}
@@ -68,12 +69,8 @@ var _ = Describe("ResultsController", func() {
 				GetJSONResponseBody(response.Result(), &jsonArrayResponse)
 
 				Expect(jsonArrayResponse.Data).To(HaveLen(1))
-				Expect(jsonArrayResponse.Data[0].Relationships.AdLinks.Data).To(HaveLen(1))
-				Expect(jsonArrayResponse.Data[0].Relationships.AdLinks.Data[0].ID).To(Equal(fmt.Sprint(adLink.ID)))
-				Expect(jsonArrayResponse.Data[0].Relationships.AdLinks.Data[0].Type).To(Equal("ad_link"))
-				Expect(jsonArrayResponse.Data[0].Relationships.Links.Data).To(HaveLen(1))
-				Expect(jsonArrayResponse.Data[0].Relationships.Links.Data[0].ID).To(Equal(fmt.Sprint(link.ID)))
-				Expect(jsonArrayResponse.Data[0].Relationships.Links.Data[0].Type).To(Equal("link"))
+				Expect(jsonArrayResponse.Data[0].Attributes.AdLinkCount).To(Equal(2))
+				Expect(jsonArrayResponse.Data[0].Attributes.LinkCount).To(Equal(1))
 			})
 		})
 
@@ -126,6 +123,8 @@ var _ = Describe("ResultsController", func() {
 					Expect(jsonArrayResponse.Data[0].ID).NotTo(BeNil())
 					Expect(jsonArrayResponse.Data[0].Attributes.Keyword).To(Equal("ergonomic chair"))
 					Expect(jsonArrayResponse.Data[0].Attributes.UserID).To(Equal(user.ID))
+					Expect(jsonArrayResponse.Data[0].Attributes.CreatedAt).To(BeNumerically(">", 0))
+					Expect(jsonArrayResponse.Data[0].Attributes.UpdatedAt).To(BeNumerically(">", 0))
 				})
 			})
 

--- a/lib/api/v1/controllers/result_test.go
+++ b/lib/api/v1/controllers/result_test.go
@@ -159,6 +159,28 @@ var _ = Describe("ResultsController", func() {
 			})
 		})
 
+		Context("given result ID that does NOT belong to the authenticated user", func() {
+			It("returns not found error", func() {
+				user := FabricateUser(faker.Email(), faker.Password())
+				anotherUser := FabricateUser(faker.Email(), faker.Password())
+				result := FabricateResult(anotherUser)
+				ctx, response := MakeJSONRequest("GET", fmt.Sprintf("/results/%d", result.ID), nil, nil, user)
+				ctx.Params = append(ctx.Params, gin.Param{Key: "id", Value: fmt.Sprint(result.ID)})
+
+				resultsController := controllers.ResultsController{}
+				resultsController.Show(ctx)
+
+				Expect(response.Code).To(Equal(http.StatusNotFound))
+
+				jsonResponse := &jsonapi.ErrorsPayload{}
+				GetJSONResponseBody(response.Result(), &jsonResponse)
+
+				Expect(jsonResponse.Errors[0].Title).To(Equal(errors.Titles[errors.ErrNotFound]))
+				Expect(jsonResponse.Errors[0].Code).To(Equal(errors.ErrNotFound.Error()))
+				Expect(jsonResponse.Errors[0].Detail).To(Equal("record not found"))
+			})
+		})
+
 		Context("given result ID dose NOT exist", func() {
 			It("returns not found error", func() {
 				user := FabricateUser(faker.Email(), faker.Password())

--- a/lib/api/v1/controllers/result_test.go
+++ b/lib/api/v1/controllers/result_test.go
@@ -55,7 +55,7 @@ var _ = Describe("ResultsController", func() {
 				Expect(jsonArrayResponse.Included[0].Attributes["email"]).To(Equal(user.Email))
 			})
 
-			It("returns number of result relations", func() {
+			It("returns the number of result relations", func() {
 				user := FabricateUser(faker.Email(), faker.Password())
 				result := FabricateResult(user)
 				FabricateLink(result)
@@ -97,7 +97,7 @@ var _ = Describe("ResultsController", func() {
 	})
 
 	Describe("GET /results/:id", func() {
-		Context("given valid result ID", func() {
+		Context("given a valid result ID", func() {
 			It("returns status ok", func() {
 				user := FabricateUser(faker.Email(), faker.Password())
 				result := FabricateResult(user)
@@ -110,7 +110,7 @@ var _ = Describe("ResultsController", func() {
 				Expect(response.Code).To(Equal(http.StatusOK))
 			})
 
-			It("returns result detail", func() {
+			It("returns the result detail", func() {
 				user := FabricateUser(faker.Email(), faker.Password())
 				result := FabricateResult(user)
 				ctx, response := MakeJSONRequest("GET", fmt.Sprintf("/results/%d", result.ID), nil, nil, user)
@@ -133,7 +133,7 @@ var _ = Describe("ResultsController", func() {
 				Expect(jsonResponse.Data.Attributes.UserID).To(Equal(result.UserID))
 			})
 
-			It("returns result relations", func() {
+			It("returns the result relations", func() {
 				user := FabricateUser(faker.Email(), faker.Password())
 				result := FabricateResult(user)
 				adLink := FabricateAdLink(result)
@@ -159,8 +159,8 @@ var _ = Describe("ResultsController", func() {
 			})
 		})
 
-		Context("given result ID that does NOT belong to the authenticated user", func() {
-			It("returns not found error", func() {
+		Context("given a result ID that does NOT belong to the authenticated user", func() {
+			It("returns error not found", func() {
 				user := FabricateUser(faker.Email(), faker.Password())
 				anotherUser := FabricateUser(faker.Email(), faker.Password())
 				result := FabricateResult(anotherUser)
@@ -181,8 +181,8 @@ var _ = Describe("ResultsController", func() {
 			})
 		})
 
-		Context("given result ID dose NOT exist", func() {
-			It("returns not found error", func() {
+		Context("given non-existing result ID", func() {
+			It("returns error not found", func() {
 				user := FabricateUser(faker.Email(), faker.Password())
 				ctx, response := MakeJSONRequest("GET", fmt.Sprintf("/results/%d", 999), nil, nil, user)
 				ctx.Params = append(ctx.Params, gin.Param{Key: "id", Value: "999"})
@@ -201,8 +201,8 @@ var _ = Describe("ResultsController", func() {
 			})
 		})
 
-		Context("given INVALID result ID", func() {
-			It("returns not found", func() {
+		Context("given an INVALID result ID", func() {
+			It("returns error bad request", func() {
 				user := FabricateUser(faker.Email(), faker.Password())
 				ctx, response := MakeJSONRequest("GET", fmt.Sprintf("/results/%s", "invalid"), nil, nil, user)
 				ctx.Params = append(ctx.Params, gin.Param{Key: "id", Value: "invalid"})

--- a/lib/api/v1/controllers/result_test.go
+++ b/lib/api/v1/controllers/result_test.go
@@ -47,6 +47,8 @@ var _ = Describe("ResultsController", func() {
 				Expect(jsonArrayResponse.Data[0].ID).To(Equal(fmt.Sprint(expectedResult.ID)))
 				Expect(jsonArrayResponse.Data[0].Attributes.Keyword).To(Equal(expectedResult.Keyword))
 				Expect(jsonArrayResponse.Data[0].Attributes.UserID).To(Equal(user.ID))
+				Expect(jsonArrayResponse.Data[0].Attributes.CreatedAt).To(Equal(expectedResult.CreatedAt.Unix()))
+				Expect(jsonArrayResponse.Data[0].Attributes.UpdatedAt).To(Equal(expectedResult.UpdatedAt.Unix()))
 				Expect(jsonArrayResponse.Included[0].Type).To(Equal("user"))
 				Expect(jsonArrayResponse.Included[0].ID).To(Equal(fmt.Sprint(user.ID)))
 				Expect(jsonArrayResponse.Included[0].Attributes["email"]).To(Equal(user.Email))

--- a/lib/api/v1/controllers/result_test.go
+++ b/lib/api/v1/controllers/result_test.go
@@ -10,6 +10,7 @@ import (
 	. "go-google-scraper-challenge/test"
 
 	"github.com/bxcodec/faker/v3"
+	"github.com/gin-gonic/gin"
 	"github.com/google/jsonapi"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -101,6 +102,7 @@ var _ = Describe("ResultsController", func() {
 				user := FabricateUser(faker.Email(), faker.Password())
 				result := FabricateResult(user)
 				ctx, response := MakeJSONRequest("GET", fmt.Sprintf("/results/%d", result.ID), nil, nil, user)
+				ctx.Params = append(ctx.Params, gin.Param{Key: "id", Value: fmt.Sprint(result.ID)})
 
 				resultsController := controllers.ResultsController{}
 				resultsController.Show(ctx)
@@ -112,6 +114,7 @@ var _ = Describe("ResultsController", func() {
 				user := FabricateUser(faker.Email(), faker.Password())
 				result := FabricateResult(user)
 				ctx, response := MakeJSONRequest("GET", fmt.Sprintf("/results/%d", result.ID), nil, nil, user)
+				ctx.Params = append(ctx.Params, gin.Param{Key: "id", Value: fmt.Sprint(result.ID)})
 
 				resultsController := controllers.ResultsController{}
 				resultsController.Show(ctx)
@@ -136,6 +139,7 @@ var _ = Describe("ResultsController", func() {
 				adLink := FabricateAdLink(result)
 				link := FabricateLink(result)
 				ctx, response := MakeJSONRequest("GET", fmt.Sprintf("/results/%d", result.ID), nil, nil, user)
+				ctx.Params = append(ctx.Params, gin.Param{Key: "id", Value: fmt.Sprint(result.ID)})
 
 				resultsController := controllers.ResultsController{}
 				resultsController.Show(ctx)

--- a/lib/api/v1/controllers/result_test.go
+++ b/lib/api/v1/controllers/result_test.go
@@ -159,27 +159,42 @@ var _ = Describe("ResultsController", func() {
 			})
 		})
 
-		Context("given INVALID result ID", func() {
+		Context("given result ID dose NOT exist", func() {
 			It("returns not found error", func() {
 				user := FabricateUser(faker.Email(), faker.Password())
 				ctx, response := MakeJSONRequest("GET", fmt.Sprintf("/results/%d", 999), nil, nil, user)
+				ctx.Params = append(ctx.Params, gin.Param{Key: "id", Value: "999"})
 
 				resultsController := controllers.ResultsController{}
 				resultsController.Show(ctx)
 
-				Expect(response.Code).To(Equal(http.StatusBadRequest))
+				Expect(response.Code).To(Equal(http.StatusNotFound))
+
+				jsonResponse := &jsonapi.ErrorsPayload{}
+				GetJSONResponseBody(response.Result(), &jsonResponse)
+
+				Expect(jsonResponse.Errors[0].Title).To(Equal(errors.Titles[errors.ErrNotFound]))
+				Expect(jsonResponse.Errors[0].Code).To(Equal(errors.ErrNotFound.Error()))
+				Expect(jsonResponse.Errors[0].Detail).To(Equal("record not found"))
 			})
 		})
 
-		Context("given NO result ID", func() {
+		Context("given INVALID result ID", func() {
 			It("returns not found", func() {
 				user := FabricateUser(faker.Email(), faker.Password())
 				ctx, response := MakeJSONRequest("GET", fmt.Sprintf("/results/%s", "invalid"), nil, nil, user)
+				ctx.Params = append(ctx.Params, gin.Param{Key: "id", Value: "invalid"})
 
 				resultsController := controllers.ResultsController{}
 				resultsController.Show(ctx)
 
 				Expect(response.Code).To(Equal(http.StatusBadRequest))
+
+				jsonResponse := &jsonapi.ErrorsPayload{}
+				GetJSONResponseBody(response.Result(), &jsonResponse)
+
+				Expect(jsonResponse.Errors[0].Title).To(Equal(errors.Titles[errors.ErrInvalidRequest]))
+				Expect(jsonResponse.Errors[0].Code).To(Equal(errors.ErrInvalidRequest.Error()))
 			})
 		})
 	})

--- a/lib/api/v1/controllers/results.go
+++ b/lib/api/v1/controllers/results.go
@@ -49,7 +49,7 @@ func (c *ResultsController) Show(ctx *gin.Context) {
 		return
 	}
 
-	result, err := models.GetResultByID(int64(resultID), []string{"User", "AdLinks", "Links"})
+	result, err := models.GetResultByID(int64(resultID), c.CurrentUser, []string{"User", "AdLinks", "Links"})
 	if err != nil {
 		RenderJSONError(ctx, errors.ErrNotFound, err.Error())
 

--- a/lib/api/v1/controllers/results.go
+++ b/lib/api/v1/controllers/results.go
@@ -37,6 +37,29 @@ func (c *ResultsController) List(ctx *gin.Context) {
 	RenderJSON(ctx, http.StatusOK, response)
 }
 
+func (c *ResultsController) Show(ctx *gin.Context) {
+	if c.EnsureAuthenticatedUser(ctx) != nil {
+		return
+	}
+
+	resultID, err := strconv.Atoi(ctx.Param("id"))
+	if err != nil {
+		RenderJSONError(ctx, errors.ErrInvalidRequest, err.Error())
+
+		return
+	}
+
+	result, err := models.GetResultByID(int64(resultID), []string{"User", "AdLinks", "Links"})
+	if err != nil {
+		RenderJSONError(ctx, errors.ErrNotFound, err.Error())
+
+		return
+	}
+
+	response := serializers.ResultSerializer{Result: result}
+	RenderJSON(ctx, http.StatusOK, response.DetailResponse())
+}
+
 func (c *ResultsController) Create(ctx *gin.Context) {
 	if c.EnsureAuthenticatedUser(ctx) != nil {
 		return
@@ -75,34 +98,4 @@ func (c *ResultsController) Create(ctx *gin.Context) {
 	}
 
 	RenderJSON(ctx, http.StatusOK, response)
-}
-
-func (c *ResultsController) Show(ctx *gin.Context) {
-	if c.EnsureAuthenticatedUser(ctx) != nil {
-		return
-	}
-
-	resultIDStr, ok := ctx.Params.Get("id")
-	if !ok {
-		RenderJSONError(ctx, errors.ErrInvalidRequest, "")
-
-		return
-	}
-
-	resultID, err := strconv.ParseInt(resultIDStr, 10, 64)
-	if err != nil {
-		RenderJSONError(ctx, errors.ErrInvalidRequest, err.Error())
-
-		return
-	}
-
-	result, err := models.GetResultByID(resultID, []string{"User", "AdLinks", "Links"})
-	if err != nil {
-		RenderJSONError(ctx, errors.ErrNotFound, err.Error())
-
-		return
-	}
-
-	response := serializers.ResultSerializer{Result: result}
-	RenderJSON(ctx, http.StatusOK, response.DetailResponse())
 }

--- a/lib/api/v1/routers/router.go
+++ b/lib/api/v1/routers/router.go
@@ -22,4 +22,5 @@ func ComebineRoutes(engine *gin.Engine) {
 	v1.POST("/login", authenticationController.Login)
 	v1.POST("/results", resultsController.Create)
 	v1.GET("/results", resultsController.List)
+	v1.GET("/results/:id", resultsController.Show)
 }

--- a/lib/api/v1/serializers/result.go
+++ b/lib/api/v1/serializers/result.go
@@ -37,8 +37,8 @@ type ResultsJSONResponse struct {
 			Status      string `json:"status"`
 			AdLinkCount int    `json:"ad_link_count"`
 			LinkCount   int    `json:"link_count"`
-			CreatedAt   int    `json:"created_at"`
-			UpdatedAt   int    `json:"updated_at"`
+			CreatedAt   int64  `json:"created_at"`
+			UpdatedAt   int64  `json:"updated_at"`
 		} `json:"attributes"`
 		Relationships struct {
 			User struct {

--- a/lib/api/v1/serializers/result.go
+++ b/lib/api/v1/serializers/result.go
@@ -1,8 +1,9 @@
 package serializers
 
 import (
-	"go-google-scraper-challenge/lib/models"
 	"time"
+
+	"go-google-scraper-challenge/lib/models"
 )
 
 type ResultResponse struct {

--- a/lib/api/v1/serializers/result.go
+++ b/lib/api/v1/serializers/result.go
@@ -2,9 +2,22 @@ package serializers
 
 import (
 	"go-google-scraper-challenge/lib/models"
+	"time"
 )
 
 type ResultResponse struct {
+	ID          int64         `jsonapi:"primary,result"`
+	Keyword     string        `jsonapi:"attr,keyword"`
+	UserID      int64         `jsonapi:"attr,user_id"`
+	Status      string        `jsonapi:"attr,status"`
+	AdLinkCount int           `jsonapi:"attr,ad_link_count"`
+	LinkCount   int           `jsonapi:"attr,link_count"`
+	User        *UserResponse `jsonapi:"relation,user,omitempty"`
+	CreatedAt   time.Time     `jsonapi:"attr,created_at"`
+	UpdatedAt   time.Time     `jsonapi:"attr,updated_at"`
+}
+
+type ResultDetailResponse struct {
 	ID        int64             `jsonapi:"primary,result"`
 	Keyword   string            `jsonapi:"attr,keyword"`
 	UserID    int64             `jsonapi:"attr,user_id"`
@@ -17,6 +30,31 @@ type ResultResponse struct {
 
 type ResultsJSONResponse struct {
 	Data []struct {
+		ID         string `json:"id"`
+		Attributes struct {
+			Keyword     string `json:"keyword"`
+			UserID      int64  `json:"user_id"`
+			Status      string `json:"status"`
+			AdLinkCount int    `json:"ad_link_count"`
+			LinkCount   int    `json:"link_count"`
+			CreatedAt   int    `json:"created_at"`
+			UpdatedAt   int    `json:"updated_at"`
+		} `json:"attributes"`
+		Relationships struct {
+			User struct {
+				Data RelationshipData `json:"data"`
+			} `json:"user"`
+		}
+	} `json:"data"`
+	Included []struct {
+		ID         string                 `json:"id"`
+		Type       string                 `json:"type"`
+		Attributes map[string]interface{} `json:"attributes"`
+	} `json:"included"`
+}
+
+type ResultDetailJSONResponse struct {
+	Data struct {
 		ID         string `json:"id"`
 		Attributes struct {
 			Keyword   string `json:"keyword"`
@@ -49,6 +87,35 @@ type ResultSerializer struct {
 
 func (s ResultSerializer) Response() (response *ResultResponse) {
 	response = &ResultResponse{
+		ID:        s.Result.ID,
+		Keyword:   s.Result.Keyword,
+		UserID:    s.Result.UserID,
+		Status:    s.Result.Status,
+		CreatedAt: s.Result.CreatedAt,
+		UpdatedAt: s.Result.UpdatedAt,
+	}
+
+	if s.Result.User != nil {
+		response.User = UserSerializer{User: s.Result.User}.Response()
+	}
+
+	if s.Result.AdLinks != nil {
+		response.AdLinkCount = len(s.Result.AdLinks)
+	} else {
+		response.AdLinkCount = 0
+	}
+
+	if s.Result.Links != nil {
+		response.LinkCount = len(s.Result.Links)
+	} else {
+		response.LinkCount = 0
+	}
+
+	return response
+}
+
+func (s ResultSerializer) DetailResponse() (response *ResultDetailResponse) {
+	response = &ResultDetailResponse{
 		ID:        s.Result.ID,
 		Keyword:   s.Result.Keyword,
 		UserID:    s.Result.UserID,

--- a/lib/api/v1/serializers/result.go
+++ b/lib/api/v1/serializers/result.go
@@ -7,18 +7,20 @@ import (
 
 type ResultResponse struct {
 	ID          int64         `jsonapi:"primary,result"`
+	CreatedAt   time.Time     `jsonapi:"attr,created_at"`
+	UpdatedAt   time.Time     `jsonapi:"attr,updated_at"`
 	Keyword     string        `jsonapi:"attr,keyword"`
 	UserID      int64         `jsonapi:"attr,user_id"`
 	Status      string        `jsonapi:"attr,status"`
 	AdLinkCount int           `jsonapi:"attr,ad_link_count"`
 	LinkCount   int           `jsonapi:"attr,link_count"`
 	User        *UserResponse `jsonapi:"relation,user,omitempty"`
-	CreatedAt   time.Time     `jsonapi:"attr,created_at"`
-	UpdatedAt   time.Time     `jsonapi:"attr,updated_at"`
 }
 
 type ResultDetailResponse struct {
 	ID        int64             `jsonapi:"primary,result"`
+	CreatedAt time.Time         `jsonapi:"attr,created_at"`
+	UpdatedAt time.Time         `jsonapi:"attr,updated_at"`
 	Keyword   string            `jsonapi:"attr,keyword"`
 	UserID    int64             `jsonapi:"attr,user_id"`
 	Status    string            `jsonapi:"attr,status"`
@@ -61,6 +63,8 @@ type ResultDetailJSONResponse struct {
 			UserID    int64  `json:"user_id"`
 			Status    string `json:"status"`
 			PageCache string `json:"page_cache"`
+			CreatedAt int64  `json:"created_at"`
+			UpdatedAt int64  `json:"updated_at"`
 		} `json:"attributes"`
 		Relationships struct {
 			User struct {
@@ -88,11 +92,11 @@ type ResultSerializer struct {
 func (s ResultSerializer) Response() (response *ResultResponse) {
 	response = &ResultResponse{
 		ID:        s.Result.ID,
+		CreatedAt: s.Result.CreatedAt,
+		UpdatedAt: s.Result.UpdatedAt,
 		Keyword:   s.Result.Keyword,
 		UserID:    s.Result.UserID,
 		Status:    s.Result.Status,
-		CreatedAt: s.Result.CreatedAt,
-		UpdatedAt: s.Result.UpdatedAt,
 	}
 
 	if s.Result.User != nil {
@@ -117,6 +121,8 @@ func (s ResultSerializer) Response() (response *ResultResponse) {
 func (s ResultSerializer) DetailResponse() (response *ResultDetailResponse) {
 	response = &ResultDetailResponse{
 		ID:        s.Result.ID,
+		CreatedAt: s.Result.CreatedAt,
+		UpdatedAt: s.Result.UpdatedAt,
 		Keyword:   s.Result.Keyword,
 		UserID:    s.Result.UserID,
 		Status:    s.Result.Status,

--- a/lib/models/result.go
+++ b/lib/models/result.go
@@ -57,10 +57,18 @@ func CreateResults(results *[]Result) ([]int64, error) {
 }
 
 // GetResultByID retrieves Result by ID. Returns error if ID doesn't exist
-func GetResultByID(id int64, preloadRelations []string) (*Result, error) {
+func GetResultByID(id int64, user *User, preloadRelations []string) (*Result, error) {
 	result := &Result{}
 
 	db := database.GetDB()
+
+	if user != nil {
+		query := map[string]interface{}{
+			"user_id": user.ID,
+		}
+
+		db = db.Where(query)
+	}
 
 	for _, relation := range preloadRelations {
 		db = db.Preload(relation)
@@ -202,7 +210,7 @@ func CountResultsBy(condition map[string]interface{}, preloadRelations []string,
 
 // UpdateResult updates Result and returns error if the record to be updated doesn't exist
 func UpdateResult(result *Result) error {
-	_, err := GetResultByID(result.ID, []string{})
+	_, err := GetResultByID(result.ID, nil, []string{})
 	if err != nil {
 		return err
 	}

--- a/lib/models/result.go
+++ b/lib/models/result.go
@@ -57,10 +57,16 @@ func CreateResults(results *[]Result) ([]int64, error) {
 }
 
 // GetResultByID retrieves Result by ID. Returns error if ID doesn't exist
-func GetResultByID(id int64) (*Result, error) {
+func GetResultByID(id int64, preloadRelations []string) (*Result, error) {
 	result := &Result{}
 
-	queryResult := database.GetDB().First(&result, id)
+	db := database.GetDB()
+
+	for _, relation := range preloadRelations {
+		db = db.Preload(relation)
+	}
+
+	queryResult := db.First(&result, id)
 	if queryResult.Error != nil {
 		return nil, queryResult.Error
 	}
@@ -196,7 +202,7 @@ func CountResultsBy(condition map[string]interface{}, preloadRelations []string,
 
 // UpdateResult updates Result and returns error if the record to be updated doesn't exist
 func UpdateResult(result *Result) error {
-	_, err := GetResultByID(result.ID)
+	_, err := GetResultByID(result.ID, []string{})
 	if err != nil {
 		return err
 	}

--- a/lib/models/result_test.go
+++ b/lib/models/result_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Result", func() {
 					Fail("Failed to add result: " + err.Error())
 				}
 
-				result, err = models.GetResultByID(resultID)
+				result, err = models.GetResultByID(resultID, []string{})
 				if err != nil {
 					Fail("Failed to add result: " + err.Error())
 				}
@@ -69,7 +69,7 @@ var _ = Describe("Result", func() {
 						Fail("Failed to add result: " + err.Error())
 					}
 
-					result, err = models.GetResultByID(resultID)
+					result, err = models.GetResultByID(resultID, []string{})
 					if err != nil {
 						Fail("Failed to add result: " + err.Error())
 					}
@@ -217,7 +217,7 @@ var _ = Describe("Result", func() {
 			It("returns result with given id", func() {
 				user := FabricateUser(faker.Email(), faker.Password())
 				existResult := FabricateResult(user)
-				result, err := models.GetResultByID(existResult.ID)
+				result, err := models.GetResultByID(existResult.ID, []string{})
 				if err != nil {
 					Fail("Failed to get result with ID")
 				}
@@ -229,7 +229,7 @@ var _ = Describe("Result", func() {
 
 		Context("given result id does NOT exist in the system", func() {
 			It("returns the error", func() {
-				result, err := models.GetResultByID(999)
+				result, err := models.GetResultByID(999, []string{})
 
 				Expect(err.Error()).To(ContainSubstring("record not found"))
 				Expect(result).To(BeNil())
@@ -836,7 +836,7 @@ var _ = Describe("Result", func() {
 					Fail("Failed to update result with ID")
 				}
 
-				result, err := models.GetResultByID(existResult.ID)
+				result, err := models.GetResultByID(existResult.ID, []string{})
 				if err != nil {
 					Fail("Failed to get result with ID")
 				}

--- a/lib/models/result_test.go
+++ b/lib/models/result_test.go
@@ -225,6 +225,27 @@ var _ = Describe("Result", func() {
 				Expect(result.Keyword).To(Equal(existResult.Keyword))
 				Expect(result.UserID).To(Equal(user.ID))
 			})
+
+			Context("given preload relations", func() {
+				It("returns result with the given relations", func() {
+					user := FabricateUser(faker.Email(), faker.Password())
+					result := FabricateResult(user)
+					adLink := FabricateAdLink(result)
+					link := FabricateLink(result)
+					result, err := models.GetResultByID(result.ID, []string{"User", "AdLinks", "Links"})
+					if err != nil {
+						Fail("Failed to get result with ID")
+					}
+
+					Expect(result.Keyword).To(Equal(result.Keyword))
+					Expect(result.UserID).To(Equal(result.UserID))
+					Expect(result.User.ID).To(Equal(result.UserID))
+					Expect(result.AdLinks).To(HaveLen(1))
+					Expect(result.AdLinks[0].ID).To(Equal(adLink.ID))
+					Expect(result.Links).To(HaveLen(1))
+					Expect(result.Links[0].ID).To(Equal(link.ID))
+				})
+			})
 		})
 
 		Context("given result id does NOT exist in the system", func() {

--- a/lib/models/result_test.go
+++ b/lib/models/result_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Result", func() {
 					Fail("Failed to add result: " + err.Error())
 				}
 
-				result, err = models.GetResultByID(resultID, []string{})
+				result, err = models.GetResultByID(resultID, nil, []string{})
 				if err != nil {
 					Fail("Failed to add result: " + err.Error())
 				}
@@ -69,7 +69,7 @@ var _ = Describe("Result", func() {
 						Fail("Failed to add result: " + err.Error())
 					}
 
-					result, err = models.GetResultByID(resultID, []string{})
+					result, err = models.GetResultByID(resultID, nil, []string{})
 					if err != nil {
 						Fail("Failed to add result: " + err.Error())
 					}
@@ -217,7 +217,7 @@ var _ = Describe("Result", func() {
 			It("returns result with given id", func() {
 				user := FabricateUser(faker.Email(), faker.Password())
 				existResult := FabricateResult(user)
-				result, err := models.GetResultByID(existResult.ID, []string{})
+				result, err := models.GetResultByID(existResult.ID, nil, []string{})
 				if err != nil {
 					Fail("Failed to get result with ID")
 				}
@@ -232,7 +232,7 @@ var _ = Describe("Result", func() {
 					result := FabricateResult(user)
 					adLink := FabricateAdLink(result)
 					link := FabricateLink(result)
-					result, err := models.GetResultByID(result.ID, []string{"User", "AdLinks", "Links"})
+					result, err := models.GetResultByID(result.ID, nil, []string{"User", "AdLinks", "Links"})
 					if err != nil {
 						Fail("Failed to get result with ID")
 					}
@@ -250,7 +250,7 @@ var _ = Describe("Result", func() {
 
 		Context("given result id does NOT exist in the system", func() {
 			It("returns the error", func() {
-				result, err := models.GetResultByID(999, []string{})
+				result, err := models.GetResultByID(999, nil, []string{})
 
 				Expect(err.Error()).To(ContainSubstring("record not found"))
 				Expect(result).To(BeNil())
@@ -857,7 +857,7 @@ var _ = Describe("Result", func() {
 					Fail("Failed to update result with ID")
 				}
 
-				result, err := models.GetResultByID(existResult.ID, []string{})
+				result, err := models.GetResultByID(existResult.ID, nil, []string{})
 				if err != nil {
 					Fail("Failed to get result with ID")
 				}

--- a/test/model.go
+++ b/test/model.go
@@ -62,7 +62,7 @@ func FabricateResultWithParams(user *models.User, keyword string, status string)
 		log.Fatal("Failed to add result " + err.Error())
 	}
 
-	result, err = models.GetResultByID(resultID)
+	result, err = models.GetResultByID(resultID, []string{})
 	if err != nil {
 		log.Fatal("Failed to get result " + err.Error())
 	}

--- a/test/model.go
+++ b/test/model.go
@@ -62,7 +62,7 @@ func FabricateResultWithParams(user *models.User, keyword string, status string)
 		log.Fatal("Failed to add result " + err.Error())
 	}
 
-	result, err = models.GetResultByID(resultID, []string{})
+	result, err = models.GetResultByID(resultID, nil, []string{})
 	if err != nil {
 		log.Fatal("Failed to get result " + err.Error())
 	}


### PR DESCRIPTION
Resolves https://github.com/carryall/go-google-scraper-challenge/issues/63

## What happened 👀

- Adjust the result list API response to have less detail
- Add result detail API  `GET /results/:id` with more detailed response

## Insight 📝

N/A

## Proof Of Work 📹

Result list API response less detail
![Screen Shot 2565-06-15 at 11 22 49](https://user-images.githubusercontent.com/1772999/173761306-c48c13c5-6df2-4f3f-af8b-de587b688fa6.png)

Result detail API response

Given valid result ID | Given result ID does not exist | Given invalid ID
--- | --- | ---
![Screen Shot 2565-06-15 at 13 48 05](https://user-images.githubusercontent.com/1772999/173761191-8217c965-5043-4344-8b98-460a33b7becf.png) | ![Screen Shot 2565-06-15 at 15 26 07](https://user-images.githubusercontent.com/1772999/173780511-8c7db843-7efe-45a0-b08d-0ed877fbc47d.png) | ![Screen Shot 2565-06-15 at 15 26 20](https://user-images.githubusercontent.com/1772999/173780542-a683e2bf-a306-4dc0-9416-3eeb3d106e45.png)

