### PR TITLE
[#9] [API] As a user, I can search the result by keyword.

### DIFF
--- a/lib/api/v1/controllers/results.go
+++ b/lib/api/v1/controllers/results.go
@@ -11,7 +11,6 @@ import (
 	"go-google-scraper-challenge/lib/models"
 
 	"github.com/gin-gonic/gin"
-	"github.com/gin-gonic/gin/binding"
 )
 
 type ResultsController struct {
@@ -23,10 +22,9 @@ func (c *ResultsController) List(ctx *gin.Context) {
 		return
 	}
 
-	resultSearchForm := &forms.ResultSearchForm{}
-	_ = ctx.ShouldBindWith(resultSearchForm, binding.JSON)
+	keyword := ctx.Query("keyword")
 
-	results, err := models.GetUserResults(c.CurrentUser.ID, []string{"User", "AdLinks", "Links"}, resultSearchForm.Keyword)
+	results, err := models.GetUserResults(c.CurrentUser.ID, []string{"User", "AdLinks", "Links"}, keyword)
 	if err != nil {
 		RenderJSONError(ctx, errors.ErrServerError, err.Error())
 

--- a/lib/api/v1/controllers/results.go
+++ b/lib/api/v1/controllers/results.go
@@ -24,7 +24,7 @@ func (c *ResultsController) List(ctx *gin.Context) {
 	}
 
 	resultSearchForm := &forms.ResultSearchForm{}
-	ctx.ShouldBindWith(resultSearchForm, binding.JSON)
+	_ = ctx.ShouldBindWith(resultSearchForm, binding.JSON)
 
 	results, err := models.GetUserResults(c.CurrentUser.ID, []string{"User", "AdLinks", "Links"}, resultSearchForm.Keyword)
 	if err != nil {

--- a/lib/api/v1/controllers/results.go
+++ b/lib/api/v1/controllers/results.go
@@ -22,7 +22,9 @@ func (c *ResultsController) List(ctx *gin.Context) {
 		return
 	}
 
-	results, err := models.GetUserResults(c.CurrentUser.ID, []string{"User", "AdLinks", "Links"})
+	filterKeyword := ctx.Query("keyword")
+
+	results, err := models.GetUserResults(c.CurrentUser.ID, []string{"User", "AdLinks", "Links"}, filterKeyword)
 	if err != nil {
 		RenderJSONError(ctx, errors.ErrServerError, err.Error())
 

--- a/lib/api/v1/controllers/results.go
+++ b/lib/api/v1/controllers/results.go
@@ -11,6 +11,7 @@ import (
 	"go-google-scraper-challenge/lib/models"
 
 	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/binding"
 )
 
 type ResultsController struct {
@@ -22,9 +23,10 @@ func (c *ResultsController) List(ctx *gin.Context) {
 		return
 	}
 
-	keyword := ctx.Query("keyword")
+	resultSearchForm := &forms.ResultSearchForm{}
+	ctx.ShouldBindWith(resultSearchForm, binding.JSON)
 
-	results, err := models.GetUserResults(c.CurrentUser.ID, []string{"User", "AdLinks", "Links"}, keyword)
+	results, err := models.GetUserResults(c.CurrentUser.ID, []string{"User", "AdLinks", "Links"}, resultSearchForm.Keyword)
 	if err != nil {
 		RenderJSONError(ctx, errors.ErrServerError, err.Error())
 

--- a/lib/api/v1/controllers/results.go
+++ b/lib/api/v1/controllers/results.go
@@ -22,9 +22,9 @@ func (c *ResultsController) List(ctx *gin.Context) {
 		return
 	}
 
-	filterKeyword := ctx.Query("keyword")
+	keyword := ctx.Query("keyword")
 
-	results, err := models.GetUserResults(c.CurrentUser.ID, []string{"User", "AdLinks", "Links"}, filterKeyword)
+	results, err := models.GetUserResults(c.CurrentUser.ID, []string{"User", "AdLinks", "Links"}, keyword)
 	if err != nil {
 		RenderJSONError(ctx, errors.ErrServerError, err.Error())
 

--- a/lib/api/v1/controllers/results_test.go
+++ b/lib/api/v1/controllers/results_test.go
@@ -83,10 +83,7 @@ var _ = Describe("ResultsController", func() {
 					result := FabricateResultWithParams(user, "mechanical keyboard", models.ResultStatusCompleted)
 					FabricateResultWithParams(user, "Khao Yai Hotel", models.ResultStatusCompleted)
 
-					requestBody := GenerateRequestBody(map[string]interface{}{
-						"keyword": "key",
-					})
-					ctx, response := MakeJSONRequest("GET", "/results", nil, requestBody, user)
+					ctx, response := MakeJSONRequest("GET", fmt.Sprintf("/results?keyword=%s", "key"), nil, nil, user)
 
 					resultsController := controllers.ResultsController{}
 					resultsController.List(ctx)
@@ -107,10 +104,7 @@ var _ = Describe("ResultsController", func() {
 						FabricateResultWithParams(user, "mechanical keyboard", models.ResultStatusCompleted)
 						FabricateResultWithParams(user, "Khao Yai Hotel", models.ResultStatusCompleted)
 
-						requestBody := GenerateRequestBody(map[string]interface{}{
-							"keyword": "other",
-						})
-						ctx, response := MakeJSONRequest("GET", "/results", nil, requestBody, user)
+						ctx, response := MakeJSONRequest("GET", fmt.Sprintf("/results?keyword=%s", "other"), nil, nil, user)
 
 						resultsController := controllers.ResultsController{}
 						resultsController.List(ctx)

--- a/lib/api/v1/controllers/results_test.go
+++ b/lib/api/v1/controllers/results_test.go
@@ -7,6 +7,7 @@ import (
 	"go-google-scraper-challenge/errors"
 	"go-google-scraper-challenge/lib/api/v1/controllers"
 	"go-google-scraper-challenge/lib/api/v1/serializers"
+	"go-google-scraper-challenge/lib/models"
 	. "go-google-scraper-challenge/test"
 
 	"github.com/bxcodec/faker/v3"
@@ -74,6 +75,54 @@ var _ = Describe("ResultsController", func() {
 				Expect(jsonArrayResponse.Data).To(HaveLen(1))
 				Expect(jsonArrayResponse.Data[0].Attributes.AdLinkCount).To(Equal(2))
 				Expect(jsonArrayResponse.Data[0].Attributes.LinkCount).To(Equal(1))
+			})
+
+			Context("given a keyword param", func() {
+				It("returns the results that contain the keyword", func() {
+					user := FabricateUser(faker.Email(), faker.Password())
+					result := FabricateResultWithParams(user, "mechanical keyboard", models.ResultStatusCompleted)
+					FabricateResultWithParams(user, "Khao Yai Hotel", models.ResultStatusCompleted)
+
+					requestBody := GenerateRequestBody(map[string]interface{}{
+						"keyword": "key",
+					})
+					ctx, response := MakeJSONRequest("GET", "/results", nil, requestBody, user)
+
+					resultsController := controllers.ResultsController{}
+					resultsController.List(ctx)
+
+					Expect(response.Code).To(Equal(http.StatusOK))
+
+					jsonArrayResponse := &serializers.ResultsJSONResponse{}
+					GetJSONResponseBody(response.Result(), &jsonArrayResponse)
+
+					Expect(jsonArrayResponse.Data).To(HaveLen(1))
+					Expect(jsonArrayResponse.Data[0].ID).To(Equal(fmt.Sprint(result.ID)))
+					Expect(jsonArrayResponse.Data[0].Attributes.Keyword).To(Equal(result.Keyword))
+				})
+
+				Context("given no result match the keyword", func() {
+					It("returns an empty array", func() {
+						user := FabricateUser(faker.Email(), faker.Password())
+						FabricateResultWithParams(user, "mechanical keyboard", models.ResultStatusCompleted)
+						FabricateResultWithParams(user, "Khao Yai Hotel", models.ResultStatusCompleted)
+
+						requestBody := GenerateRequestBody(map[string]interface{}{
+							"keyword": "other",
+						})
+						ctx, response := MakeJSONRequest("GET", "/results", nil, requestBody, user)
+
+						resultsController := controllers.ResultsController{}
+						resultsController.List(ctx)
+
+						Expect(response.Code).To(Equal(http.StatusOK))
+
+						jsonArrayResponse := &serializers.ResultsJSONResponse{}
+						GetJSONResponseBody(response.Result(), &jsonArrayResponse)
+
+						Expect(jsonArrayResponse.Data).To(HaveLen(0))
+					})
+				})
 			})
 		})
 

--- a/lib/api/v1/forms/result_search.go
+++ b/lib/api/v1/forms/result_search.go
@@ -1,0 +1,15 @@
+package forms
+
+import (
+	validation "github.com/go-ozzo/ozzo-validation"
+)
+
+type ResultSearchForm struct {
+	Keyword string `json:"keyword"`
+}
+
+func (f ResultSearchForm) Validate() error {
+	return validation.ValidateStruct(&f,
+		validation.Field(&f.Keyword),
+	)
+}

--- a/lib/api/v1/forms/result_search.go
+++ b/lib/api/v1/forms/result_search.go
@@ -1,5 +1,0 @@
-package forms
-
-type ResultSearchForm struct {
-	Keyword string `json:"keyword"`
-}

--- a/lib/api/v1/forms/result_search.go
+++ b/lib/api/v1/forms/result_search.go
@@ -1,15 +1,5 @@
 package forms
 
-import (
-	validation "github.com/go-ozzo/ozzo-validation"
-)
-
 type ResultSearchForm struct {
 	Keyword string `json:"keyword"`
-}
-
-func (f ResultSearchForm) Validate() error {
-	return validation.ValidateStruct(&f,
-		validation.Field(&f.Keyword),
-	)
 }

--- a/lib/models/result.go
+++ b/lib/models/result.go
@@ -94,7 +94,7 @@ func GetResultsByIDs(id []int64) (*[]Result, error) {
 	return results, nil
 }
 
-func GetUserResults(userID int64, preloadRelations []string) (results []*Result, err error) {
+func GetUserResults(userID int64, preloadRelations []string, keyword string) (results []*Result, err error) {
 	query := map[string]interface{}{
 		"user_id": userID,
 	}
@@ -103,6 +103,10 @@ func GetUserResults(userID int64, preloadRelations []string) (results []*Result,
 
 	for _, relation := range preloadRelations {
 		db = db.Preload(relation)
+	}
+
+	if len(keyword) > 0 {
+		db = db.Where("keyword ILIKE '%' || ? || '%'", keyword)
 	}
 
 	queryResult := db.Find(&results, query)

--- a/lib/models/result_test.go
+++ b/lib/models/result_test.go
@@ -723,7 +723,7 @@ var _ = Describe("Result", func() {
 					result2 := FabricateResult(user)
 					result3 := FabricateResult(anotherUser)
 
-					results, err := models.GetUserResults(user.ID, []string{})
+					results, err := models.GetUserResults(user.ID, []string{}, "")
 
 					Expect(err).To(BeNil())
 
@@ -744,7 +744,7 @@ var _ = Describe("Result", func() {
 						FabricateResult(user)
 						FabricateResult(anotherUser)
 
-						results, err := models.GetUserResults(user.ID, []string{"User"})
+						results, err := models.GetUserResults(user.ID, []string{"User"}, "")
 
 						Expect(err).To(BeNil())
 
@@ -754,13 +754,28 @@ var _ = Describe("Result", func() {
 						}
 					})
 				})
+
+				Context("given the search keyword", func() {
+					It("returns the results that contain the keyword", func() {
+						user := FabricateUser(faker.Email(), faker.Password())
+						expectedResult := FabricateResultWithParams(user, "keyword", models.ResultStatusCompleted)
+						FabricateResultWithParams(user, "non related", models.ResultStatusCompleted)
+
+						results, err := models.GetUserResults(user.ID, []string{"User"}, "word")
+
+						Expect(err).To(BeNil())
+						Expect(results).To(HaveLen(1))
+						Expect(results[0].ID).To(Equal(expectedResult.ID))
+						Expect(results[0].Keyword).To(Equal(expectedResult.Keyword))
+					})
+				})
 			})
 
 			Context("given user ID without results", func() {
 				It("returns a blank array of result", func() {
 					user := FabricateUser(faker.Email(), faker.Password())
 
-					results, err := models.GetUserResults(user.ID, []string{})
+					results, err := models.GetUserResults(user.ID, []string{}, "")
 
 					Expect(err).To(BeNil())
 					Expect(results).To(HaveLen(0))
@@ -771,7 +786,7 @@ var _ = Describe("Result", func() {
 		Context("given invalid params", func() {
 			Context("given an INVALID user ID", func() {
 				It("returns a blank array of result", func() {
-					results, err := models.GetUserResults(999, []string{})
+					results, err := models.GetUserResults(999, []string{}, "")
 
 					Expect(err).To(BeNil())
 					Expect(results).To(HaveLen(0))

--- a/lib/models/result_test.go
+++ b/lib/models/result_test.go
@@ -755,7 +755,7 @@ var _ = Describe("Result", func() {
 					})
 				})
 
-				Context("given the search keyword", func() {
+				Context("given an existing search keyword", func() {
 					It("returns the results that contain the keyword", func() {
 						user := FabricateUser(faker.Email(), faker.Password())
 						expectedResult := FabricateResultWithParams(user, "keyword", models.ResultStatusCompleted)

--- a/lib/services/scraper/scraper_test.go
+++ b/lib/services/scraper/scraper_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Scraper", func() {
 					Fail("Failed to run scraper service")
 				}
 
-				userResults, err := models.GetUserResults(user.ID, []string{"User", "AdLinks", "Links"})
+				userResults, err := models.GetUserResults(user.ID, []string{"User", "AdLinks", "Links"}, "")
 				if err != nil {
 					Fail("Failed to get user results")
 				}

--- a/test/controller.go
+++ b/test/controller.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -49,6 +50,15 @@ func HTTPRequest(method string, url string, body io.Reader) *http.Request {
 	}
 
 	return request
+}
+
+func GenerateRequestBody(params map[string]interface{}) *bytes.Buffer {
+	queryParams, err := json.Marshal(params)
+	if err != nil {
+		ginkgo.Fail("Cannot parse the request body")
+	}
+
+	return bytes.NewBuffer(queryParams)
 }
 
 // GetJSONResponseBody get response body from response, will fail the test if there is any error


### PR DESCRIPTION
Resolves https://github.com/carryall/go-google-scraper-challenge/issues/9

## What happened 👀

Add keyword param to the `GET /results` API to filter the result with the keyword

## Insight 📝

N/A

## Proof Of Work 📹

Response preview

Given no keyword | Given some result with keyword | Given no result with the keyword
--- | --- | ---
![Screen Shot 2565-06-16 at 12 44 46](https://user-images.githubusercontent.com/1772999/173999951-4457d777-f816-4c1b-ada9-b047137a9dde.png) | ![Screen Shot 2565-06-16 at 12 43 07](https://user-images.githubusercontent.com/1772999/173999979-8c319eab-7c7d-4347-bb54-71ce51f4d31c.png) | ![Screen Shot 2565-06-16 at 12 38 22](https://user-images.githubusercontent.com/1772999/174000012-b7613e96-5e3b-4d3e-ad34-fb06671dffbe.png)


